### PR TITLE
Change LogLevelFilter.java constructor modifier to public

### DIFF
--- a/src/org/sosy_lab/common/log/LogLevelFilter.java
+++ b/src/org/sosy_lab/common/log/LogLevelFilter.java
@@ -31,7 +31,7 @@ class LogLevelFilter implements Filter {
 
   private final Set<Level> excludeLevels;
 
-  LogLevelFilter(List<Level> excludeLevels) {
+  public LogLevelFilter(List<Level> excludeLevels) {
     this.excludeLevels = ImmutableSet.copyOf(excludeLevels);
   }
 

--- a/src/org/sosy_lab/common/log/LogLevelFilter.java
+++ b/src/org/sosy_lab/common/log/LogLevelFilter.java
@@ -27,7 +27,7 @@ import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
 /** {@link Filter} implementation for blacklisting log levels. */
-class LogLevelFilter implements Filter {
+public class LogLevelFilter implements Filter {
 
   private final Set<Level> excludeLevels;
 


### PR DESCRIPTION
I am quite sure that the modifier should be public, in order to allow users to reuse this filter. 