### PR TITLE
Log manager interface extension

### DIFF
--- a/src/org/sosy_lab/common/log/BasicLogManagerTest.java
+++ b/src/org/sosy_lab/common/log/BasicLogManagerTest.java
@@ -139,6 +139,7 @@ public class BasicLogManagerTest {
         Level.SEVERE,
         "|",
         new AbstractAppender() {
+
           @Override
           public void appendTo(Appendable pAppendable) throws IOException {
             pAppendable.append(LONG_STRING);

--- a/src/org/sosy_lab/common/log/ForwardingLogManager.java
+++ b/src/org/sosy_lab/common/log/ForwardingLogManager.java
@@ -57,8 +57,18 @@ public abstract class ForwardingLogManager implements LogManager {
   }
 
   @Override
+  public void logfUserException(Level pPriority, Throwable pE, String pFormat, Object... pArgs) {
+    delegate().logfUserException(pPriority, pE, pFormat, pArgs);
+  }
+
+  @Override
   public void logDebugException(Throwable pE, @Nullable String pAdditionalMessage) {
     delegate().logDebugException(pE, pAdditionalMessage);
+  }
+
+  @Override
+  public void logfDebugException(Throwable pE, String pFormat, Object... pArgs) {
+    delegate().logfDebugException(pE, pFormat, pArgs);
   }
 
   @Override
@@ -69,6 +79,11 @@ public abstract class ForwardingLogManager implements LogManager {
   @Override
   public void logException(Level pPriority, Throwable pE, @Nullable String pAdditionalMessage) {
     delegate().logException(pPriority, pE, pAdditionalMessage);
+  }
+
+  @Override
+  public void logfException(Level pPriority, Throwable pE, String pFormat, Object... pArgs) {
+    delegate().logfException(pPriority, pE, pFormat, pArgs);
   }
 
   @Override

--- a/src/org/sosy_lab/common/log/LogManager.java
+++ b/src/org/sosy_lab/common/log/LogManager.java
@@ -105,6 +105,27 @@ public interface LogManager {
   void logUserException(Level priority, Throwable e, @Nullable String additionalMessage);
 
   /**
+   * Log a message by printing its message to the user. The details (e.g., stack trace) are hidden
+   * from the user and logged with a lower log level.
+   *
+   * <p>Use this method in cases where an expected exception with a useful error message is thrown,
+   * e.g. an InvalidConfigurationException.
+   *
+   * <p>The message is constructed lazily from <code>String.format(format, args)</code>. To make
+   * individual arguments lazy, use {@link MoreStrings#lazyString(Supplier)}.
+   *
+   * <p>If you want to log an IOException because of a write error, it is recommended to write the
+   * message like "Could not write FOO to file". The final message will then be "Could not write FOO
+   * to file FOO.txt (REASON)".
+   *
+   * @param priority the log level for the message
+   * @param e the occurred exception
+   * @param format The format string.
+   * @param args The arguments for the format string.
+   */
+  void logfUserException(Level priority, Throwable e, String format, Object... args);
+
+  /**
    * Log an exception solely for the purpose of debugging. In default configuration, this exception
    * is not shown to the user!
    *
@@ -115,6 +136,22 @@ public interface LogManager {
    * @param additionalMessage an optional message
    */
   void logDebugException(Throwable e, @Nullable String additionalMessage);
+
+  /**
+   * Log an exception solely for the purpose of debugging. In default configuration, this exception
+   * is not shown to the user!
+   *
+   * <p>Use this method when you want to log an exception that was handled by the catching site, but
+   * you don't want to forget the information completely.
+   *
+   * <p>The message is constructed lazily from <code>String.format(format, args)</code>. To make
+   * individual arguments lazy, use {@link MoreStrings#lazyString(Supplier)}.
+   *
+   * @param e the occurred exception
+   * @param format The format string.
+   * @param args The arguments for the format string.
+   */
+  void logfDebugException(Throwable e, String format, Object... args);
 
   /**
    * Log an exception solely for the purpose of debugging. In default configuration, this exception
@@ -138,6 +175,22 @@ public interface LogManager {
    * @param additionalMessage an optional message
    */
   void logException(Level priority, Throwable e, @Nullable String additionalMessage);
+
+  /**
+   * Log an exception by printing the full details to the user.
+   *
+   * <p>This method should only be used in cases where logUserException and logDebugException are
+   * not acceptable.
+   *
+   * <p>The message is constructed lazily from <code>String.format(format, args)</code>. To make
+   * individual arguments lazy, use {@link MoreStrings#lazyString(Supplier)}.
+   *
+   * @param priority the log level for the message
+   * @param e the occurred exception
+   * @param format The format string.
+   * @param args The arguments for the format string.
+   */
+  void logfException(Level priority, Throwable e, String format, Object... args);
 
   /** Flush all handlers of this logger. */
   void flush();

--- a/src/org/sosy_lab/common/log/LoggingOptions.java
+++ b/src/org/sosy_lab/common/log/LoggingOptions.java
@@ -92,6 +92,12 @@ public class LoggingOptions {
     config.inject(this);
   }
 
+  /**
+   * This constructor is for inheritance, thus allowing users to use this class without sosy-lab's
+   * {@link Configuration}.
+   */
+  protected LoggingOptions() {}
+
   public Level getFileLevel() {
     return fileLevel;
   }

--- a/src/org/sosy_lab/common/log/NullLogManager.java
+++ b/src/org/sosy_lab/common/log/NullLogManager.java
@@ -61,13 +61,22 @@ public enum NullLogManager implements LogManager {
   public void logUserException(Level pPriority, Throwable pE, String pAdditionalMessage) {}
 
   @Override
+  public void logfUserException(Level pPriority, Throwable pE, String pFormat, Object... pArgs) {}
+
+  @Override
   public void logDebugException(Throwable pE, String pAdditionalMessage) {}
+
+  @Override
+  public void logfDebugException(Throwable pE, String pFormat, Object... pArgs) {}
 
   @Override
   public void logDebugException(Throwable pE) {}
 
   @Override
   public void logException(Level pPriority, Throwable pE, String pAdditionalMessage) {}
+
+  @Override
+  public void logfException(Level pPriority, Throwable pE, String pFormat, Object... pArgs) {}
 
   @Override
   public void flush() {}

--- a/src/org/sosy_lab/common/log/TestLogManager.java
+++ b/src/org/sosy_lab/common/log/TestLogManager.java
@@ -61,47 +61,88 @@ public enum TestLogManager implements LogManager {
 
   @Override
   public void log(Level pPriority, Object... pArgs) {
-    checkNotNull(pPriority);
-    checkNotNull(pArgs);
-    checkArgument(pArgs.length != 0);
-    // Convert arguments array to string to check that no toString() method throws an exception.
-    checkArgument(!Arrays.deepToString(pArgs).isEmpty());
+    checkLogBaseParam(pPriority);
+    checkObjectArgsConcatenationParams(pArgs);
   }
 
   @Override
   public void log(Level pPriority, Supplier<String> pMsgSupplier) {
-    checkNotNull(pPriority);
+    checkLogBaseParam(pPriority);
     checkNotNull(pMsgSupplier.get());
   }
 
   @Override
   public void logf(Level pPriority, String pFormat, Object... pArgs) {
+    checkLogBaseParam(pPriority);
+    checkFormatParamsNotNull(pFormat, pArgs);
+  }
+
+  private static void checkLogBaseParam(Level pPriority) {
     checkNotNull(pPriority);
-    checkNotNull(pFormat);
-    checkNotNull(pArgs);
-    checkArgument(!String.format(pFormat, pArgs).isEmpty());
   }
 
   @Override
   public void logUserException(Level pPriority, Throwable pE, @Nullable String pAdditionalMessage) {
+    checkUserExceptionBaseParams(pPriority, pE);
+  }
+
+  @Override
+  public void logfUserException(Level pPriority, Throwable pE, String pFormat, Object... pArgs) {
+    checkUserExceptionBaseParams(pPriority, pE);
+    checkFormatParamsNotNull(pFormat, pArgs);
+  }
+
+  private static void checkUserExceptionBaseParams(Level pPriority, Throwable pE) {
     checkNotNull(pPriority);
     checkNotNull(pE);
   }
 
   @Override
   public void logDebugException(Throwable pE, @Nullable String pAdditionalMessage) {
-    checkNotNull(pE);
+    checkLogDebugExceptionBaseParams(pE);
+  }
+
+  @Override
+  public void logfDebugException(Throwable pE, String pFormat, Object... pArgs) {
+    checkLogDebugExceptionBaseParams(pE);
+    checkFormatParamsNotNull(pFormat, pArgs);
   }
 
   @Override
   public void logDebugException(Throwable pE) {
+    checkLogDebugExceptionBaseParams(pE);
+  }
+
+  private static void checkLogDebugExceptionBaseParams(Throwable pE) {
     checkNotNull(pE);
   }
 
   @Override
   public void logException(Level pPriority, Throwable pE, @Nullable String pAdditionalMessage) {
+    checkLogExceptionBaseParams(pPriority, pE);
+  }
+
+  @Override
+  public void logfException(Level pPriority, Throwable pE, String pFormat, Object... pArgs) {
+    checkLogExceptionBaseParams(pPriority, pE);
+    checkFormatParamsNotNull(pFormat, pArgs);
+  }
+
+  private static void checkLogExceptionBaseParams(Level pPriority, Throwable pE) {
     checkNotNull(pPriority);
     checkNotNull(pE);
+  }
+
+  private static void checkFormatParamsNotNull(String pFormat, Object... pArgs) {
+    checkNotNull(pArgs);
+    checkArgument(!String.format(pFormat, pArgs).isEmpty());
+  }
+
+  private static void checkObjectArgsConcatenationParams(Object... pArgs) {
+    checkNotNull(pArgs);
+    checkArgument(pArgs.length != 0);
+    // Convert arguments array to string to check that no toString() method throws an exception.
+    checkArgument(!Arrays.deepToString(pArgs).isEmpty());
   }
 
   @Override


### PR DESCRIPTION
Implementation proposal to resolve #12.

Introduced `log( ... , Object... args)` and `logf(... , String format, Object... args)` for:
- `logUserException`
- `logDebugException`
- `logException`

Removed `logException(Throwable e)` since it's kind of the same as calling `logException(Throwable e,  Object... args)` with no additional arguments.

Dropped `@Nullable String` parameter altogether.
For old `log(.... , null)` calls, it will cause a compiler warning

