### PR TITLE
Initial OrderStatisticMap/Set

### DIFF
--- a/src/org/sosy_lab/common/collect/NaiveOrderStatisticMap.java
+++ b/src/org/sosy_lab/common/collect/NaiveOrderStatisticMap.java
@@ -35,8 +35,8 @@ import java.util.TreeMap;
  *
  * <p>The class wraps a {@link NavigableMap} object and delegates all methods inherited from the
  * <code>NavigableMap</code> interface to that. For the methods particular to the <code>
- * OrderStatisticMap</code> interface, it provides naive implementations that do not guarantee any
- * specific performance.
+ * OrderStatisticMap</code> interface, it provides naive implementations that do guarantee
+ * performance only in O(n).
  *
  * @param <K> type of the keys of this map. See the Javadoc of {@link OrderStatisticMap} for
  *     possible constraints on this type

--- a/src/org/sosy_lab/common/collect/NaiveOrderStatisticMap.java
+++ b/src/org/sosy_lab/common/collect/NaiveOrderStatisticMap.java
@@ -1,0 +1,162 @@
+/*
+ *  SoSy-Lab Common is a library of useful utilities.
+ *  This file is part of SoSy-Lab Common.
+ *
+ *  Copyright (C) 2007-2017  Dirk Beyer
+ *  All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.sosy_lab.common.collect;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.collect.ForwardingNavigableMap;
+import com.google.common.collect.Maps;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import java.io.Serializable;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+
+/**
+ * An {@link OrderStatisticMap} with naive implementations of its functions.
+ *
+ * <p>The class wraps a {@link NavigableMap} object and delegates all methods inherited from the
+ * <code>NavigableMap</code> interface to that. For the methods particular to the <code>
+ * OrderStatisticMap</code> interface, it provides naive implementations that do not guarantee any
+ * specific performance.
+ *
+ * @param <K> type of the keys of this map. See the Javadoc of {@link OrderStatisticMap} for
+ *     possible constraints on this type
+ * @param <V> type of the values of this map
+ * @see OrderStatisticMap
+ */
+final class NaiveOrderStatisticMap<K, V> extends ForwardingNavigableMap<K, V>
+    implements OrderStatisticMap<K, V>, Serializable {
+
+  private static final long serialVersionUID = -3542217590830996599L;
+
+  private final NavigableMap<K, V> delegate;
+
+  private NaiveOrderStatisticMap(NavigableMap<K, ? extends V> pNavigableMap) {
+    delegate = new TreeMap<>(pNavigableMap);
+  }
+
+  /** Creates a new empty OrderStatisticMap using natural ordering. */
+  static <K, V> NaiveOrderStatisticMap<K, V> createMap() {
+    return new NaiveOrderStatisticMap<>(new TreeMap<>());
+  }
+
+  /** Creates a new empty OrderStatisticMap using the given comparator over its keys. */
+  static <K, V> NaiveOrderStatisticMap<K, V> createMap(Comparator<? super K> pComparator) {
+    return new NaiveOrderStatisticMap<>(new TreeMap<>(checkNotNull(pComparator)));
+  }
+
+  /**
+   * Creates a new OrderStatisticSet containing the same entries as the given map, using natural
+   * ordering over its keys.
+   */
+  static <K, V> NaiveOrderStatisticMap<K, V> createMapWithNaturalOrder(
+      Map<? extends K, ? extends V> pMap) {
+    return new NaiveOrderStatisticMap<>(new TreeMap<>(checkNotNull(pMap)));
+  }
+
+  /**
+   * Creates a new OrderStatisticMap containing the sames entries as the given map and using the
+   * same ordering over its keys as the given map.
+   */
+  static <K, V> NaiveOrderStatisticMap<K, V> createMapWithSameOrder(
+      NavigableMap<K, ? extends V> pNavigableMap) {
+    return new NaiveOrderStatisticMap<>(checkNotNull(pNavigableMap));
+  }
+
+  @Override
+  protected NavigableMap<K, V> delegate() {
+    return delegate;
+  }
+
+  @Override
+  public K getKeyByRank(int pIndex) {
+    return NaiveOrderStatisticSet.createSetWithSameOrder(delegate.navigableKeySet())
+        .getByRank(pIndex);
+  }
+
+  @Override
+  public Entry<K, V> getEntryByRank(int pIndex) {
+    K key = getKeyByRank(pIndex);
+    return Maps.immutableEntry(key, get(key));
+  }
+
+  @Override
+  @CanIgnoreReturnValue
+  public K removeByRank(int pIndex) {
+    K key = getKeyByRank(pIndex);
+    V val = remove(key);
+    assert val != null : "Key could be retrieved by rank, but no (or null) value associated";
+    return key;
+  }
+
+  @Override
+  public int rankOf(K pObj) {
+    checkNotNull(pObj);
+    return NaiveOrderStatisticSet.createSetWithSameOrder(delegate.navigableKeySet()).rankOf(pObj);
+  }
+
+  @Override
+  public OrderStatisticSet<K> navigableKeySet() {
+    return NaiveOrderStatisticSet.createSetWithSameOrder(super.navigableKeySet());
+  }
+
+  @Override
+  public OrderStatisticSet<K> descendingKeySet() {
+    return NaiveOrderStatisticSet.createSetWithSameOrder(super.descendingKeySet());
+  }
+
+  @Override
+  public OrderStatisticMap<K, V> descendingMap() {
+    return new NaiveOrderStatisticMap<>(super.descendingMap());
+  }
+
+  @Override
+  public OrderStatisticMap<K, V> subMap(
+      K fromKey, boolean fromInclusive, K toKey, boolean toInclusive) {
+    return new NaiveOrderStatisticMap<>(super.subMap(fromKey, fromInclusive, toKey, toInclusive));
+  }
+
+  @Override
+  public OrderStatisticMap<K, V> headMap(K toKey, boolean inclusive) {
+    return new NaiveOrderStatisticMap<>(super.headMap(toKey, inclusive));
+  }
+
+  @Override
+  public OrderStatisticMap<K, V> tailMap(K fromKey, boolean inclusive) {
+    return new NaiveOrderStatisticMap<>(super.tailMap(fromKey, inclusive));
+  }
+
+  @Override
+  public OrderStatisticMap<K, V> headMap(K toKey) {
+    return headMap(toKey, /* inclusive= */ false);
+  }
+
+  @Override
+  public OrderStatisticMap<K, V> subMap(K fromKey, K toKey) {
+    return subMap(fromKey, /* fromInclusive= */ true, toKey, /* toInclusive= */ false);
+  }
+
+  @Override
+  public OrderStatisticMap<K, V> tailMap(K fromKey) {
+    return tailMap(fromKey, /* inclusive= */ true);
+  }
+}

--- a/src/org/sosy_lab/common/collect/NaiveOrderStatisticMap.java
+++ b/src/org/sosy_lab/common/collect/NaiveOrderStatisticMap.java
@@ -29,6 +29,7 @@ import java.io.Serializable;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.NavigableMap;
+import java.util.SortedMap;
 import java.util.TreeMap;
 
 /**
@@ -79,8 +80,8 @@ final class NaiveOrderStatisticMap<K, V> extends ForwardingNavigableMap<K, V>
    * same ordering over its keys as the given map.
    */
   static <K, V> NaiveOrderStatisticMap<K, V> createMapWithSameOrder(
-      NavigableMap<K, ? extends V> pNavigableMap) {
-    return new NaiveOrderStatisticMap<>(new TreeMap<>(checkNotNull(pNavigableMap)));
+      SortedMap<K, ? extends V> pSortedMap) {
+    return new NaiveOrderStatisticMap<>(new TreeMap<>(checkNotNull(pSortedMap)));
   }
 
   @Override

--- a/src/org/sosy_lab/common/collect/NaiveOrderStatisticMap.java
+++ b/src/org/sosy_lab/common/collect/NaiveOrderStatisticMap.java
@@ -51,8 +51,8 @@ final class NaiveOrderStatisticMap<K, V> extends ForwardingNavigableMap<K, V>
 
   private final NavigableMap<K, V> delegate;
 
-  private NaiveOrderStatisticMap(NavigableMap<K, ? extends V> pNavigableMap) {
-    delegate = new TreeMap<>(pNavigableMap);
+  private NaiveOrderStatisticMap(NavigableMap<K, V> pNavigableMap) {
+    delegate = pNavigableMap;
   }
 
   /** Creates a new empty OrderStatisticMap using natural ordering. */
@@ -80,7 +80,7 @@ final class NaiveOrderStatisticMap<K, V> extends ForwardingNavigableMap<K, V>
    */
   static <K, V> NaiveOrderStatisticMap<K, V> createMapWithSameOrder(
       NavigableMap<K, ? extends V> pNavigableMap) {
-    return new NaiveOrderStatisticMap<>(checkNotNull(pNavigableMap));
+    return new NaiveOrderStatisticMap<>(new TreeMap<>(checkNotNull(pNavigableMap)));
   }
 
   @Override
@@ -126,12 +126,12 @@ final class NaiveOrderStatisticMap<K, V> extends ForwardingNavigableMap<K, V>
 
   @Override
   public OrderStatisticSet<K> navigableKeySet() {
-    return NaiveOrderStatisticSet.createSetWithSameOrder(super.navigableKeySet());
+    return NaiveOrderStatisticSet.createView(super.navigableKeySet());
   }
 
   @Override
   public OrderStatisticSet<K> descendingKeySet() {
-    return NaiveOrderStatisticSet.createSetWithSameOrder(super.descendingKeySet());
+    return NaiveOrderStatisticSet.createView(super.descendingKeySet());
   }
 
   @Override

--- a/src/org/sosy_lab/common/collect/NaiveOrderStatisticMap.java
+++ b/src/org/sosy_lab/common/collect/NaiveOrderStatisticMap.java
@@ -22,6 +22,7 @@ package org.sosy_lab.common.collect;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.ForwardingNavigableMap;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.io.Serializable;
@@ -89,8 +90,7 @@ final class NaiveOrderStatisticMap<K, V> extends ForwardingNavigableMap<K, V>
 
   @Override
   public K getKeyByRank(int pIndex) {
-    return NaiveOrderStatisticSet.createSetWithSameOrder(delegate.navigableKeySet())
-        .getByRank(pIndex);
+    return Iterables.get(delegate.navigableKeySet(), pIndex);
   }
 
   @Override
@@ -111,7 +111,17 @@ final class NaiveOrderStatisticMap<K, V> extends ForwardingNavigableMap<K, V>
   @Override
   public int rankOf(K pObj) {
     checkNotNull(pObj);
-    return NaiveOrderStatisticSet.createSetWithSameOrder(delegate.navigableKeySet()).rankOf(pObj);
+    return Iterables.indexOf(delegate.navigableKeySet(), o -> compareKey(o, pObj) == 0);
+  }
+
+  @SuppressWarnings("unchecked")
+  private int compareKey(K pFirst, K pSnd) {
+    Comparator<? super K> comparator = comparator();
+    if (comparator != null) {
+      return comparator.compare(pFirst, pSnd);
+    } else {
+      return ((Comparable<K>) pFirst).compareTo(pSnd);
+    }
   }
 
   @Override

--- a/src/org/sosy_lab/common/collect/NaiveOrderStatisticMapTest.java
+++ b/src/org/sosy_lab/common/collect/NaiveOrderStatisticMapTest.java
@@ -1,0 +1,101 @@
+/*
+ *  SoSy-Lab Common is a library of useful utilities.
+ *  This file is part of SoSy-Lab Common.
+ *
+ *  Copyright (C) 2007-2017  Dirk Beyer
+ *  All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.sosy_lab.common.collect;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.testing.NavigableMapTestSuiteBuilder;
+import com.google.common.collect.testing.TestSortedMapGenerator;
+import com.google.common.collect.testing.features.CollectionFeature;
+import com.google.common.collect.testing.features.CollectionSize;
+import com.google.common.collect.testing.features.MapFeature;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import junit.framework.JUnit4TestAdapter;
+import junit.framework.TestSuite;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class NaiveOrderStatisticMapTest extends OrderStatisticMapTestSuite {
+
+  private static class OrderStatisticMapProxyFactory extends OrderStatisticMapFactory {
+
+    @Override
+    protected OrderStatisticMap<String, String> create(Entry<String, String>[] pEntries) {
+      return create(Arrays.asList(pEntries));
+    }
+
+    @Override
+    protected OrderStatisticMap<String, String> create(List<Entry<String, String>> pEntries) {
+      NaiveOrderStatisticMap<String, String> map = createMap();
+      for (Entry<String, String> e : pEntries) {
+        map.put(e.getKey(), e.getValue());
+      }
+      return map;
+    }
+
+    private static <K, V> NaiveOrderStatisticMap<K, V> createMap() {
+      return NaiveOrderStatisticMap.createMap();
+    }
+  }
+
+  public NaiveOrderStatisticMapTest() {
+    super(new OrderStatisticMapProxyFactory());
+  }
+
+  public static junit.framework.Test suite() {
+    TestSortedMapGenerator<String, String> testSetGenerator = new OrderStatisticMapProxyFactory();
+
+    TestSuite suite =
+        NavigableMapTestSuiteBuilder.using(testSetGenerator)
+            .named("NaiveOrderStatisticMap")
+            .withFeatures(
+                CollectionSize.ANY,
+                CollectionFeature.KNOWN_ORDER,
+                CollectionFeature.SERIALIZABLE,
+                CollectionFeature.SUPPORTS_ITERATOR_REMOVE,
+                CollectionFeature.SUBSET_VIEW,
+                MapFeature.GENERAL_PURPOSE,
+                MapFeature.SUPPORTS_REMOVE,
+                MapFeature.SUPPORTS_PUT,
+                MapFeature.ALLOWS_NULL_VALUES)
+            .createTestSuite();
+
+    suite.addTest(new JUnit4TestAdapter(NaiveOrderStatisticSetTest.class));
+
+    return suite;
+  }
+
+  @Test
+  public void testNoReference() {
+    NavigableMap<String, String> testMap =
+        new TreeMap<>(ImmutableMap.of("a", "Va", "b", "Vb", "bc", "Vbc", "d", "Vd"));
+    OrderStatisticMap<String, String> map = NaiveOrderStatisticMap.createMapWithSameOrder(testMap);
+
+    testMap.remove("a");
+    Assert.assertFalse(testMap.containsKey("a"));
+    Assert.assertTrue(map.containsKey("a"));
+    map.remove("bc");
+    Assert.assertTrue(testMap.containsKey("bc"));
+    Assert.assertFalse(map.containsKey("bc"));
+  }
+}

--- a/src/org/sosy_lab/common/collect/NaiveOrderStatisticMapTest.java
+++ b/src/org/sosy_lab/common/collect/NaiveOrderStatisticMapTest.java
@@ -74,13 +74,14 @@ public class NaiveOrderStatisticMapTest extends OrderStatisticMapTestSuite {
                 CollectionFeature.SERIALIZABLE,
                 CollectionFeature.SUPPORTS_ITERATOR_REMOVE,
                 CollectionFeature.SUBSET_VIEW,
+                CollectionFeature.DESCENDING_VIEW,
                 MapFeature.GENERAL_PURPOSE,
                 MapFeature.SUPPORTS_REMOVE,
                 MapFeature.SUPPORTS_PUT,
                 MapFeature.ALLOWS_NULL_VALUES)
             .createTestSuite();
 
-    suite.addTest(new JUnit4TestAdapter(NaiveOrderStatisticSetTest.class));
+    suite.addTest(new JUnit4TestAdapter(NaiveOrderStatisticMapTest.class));
 
     return suite;
   }

--- a/src/org/sosy_lab/common/collect/NaiveOrderStatisticMapTest.java
+++ b/src/org/sosy_lab/common/collect/NaiveOrderStatisticMapTest.java
@@ -19,6 +19,8 @@
  */
 package org.sosy_lab.common.collect;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.testing.NavigableMapTestSuiteBuilder;
 import com.google.common.collect.testing.TestSortedMapGenerator;
@@ -32,7 +34,6 @@ import java.util.NavigableMap;
 import java.util.TreeMap;
 import junit.framework.JUnit4TestAdapter;
 import junit.framework.TestSuite;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class NaiveOrderStatisticMapTest extends OrderStatisticMapTestSuite {
@@ -93,10 +94,10 @@ public class NaiveOrderStatisticMapTest extends OrderStatisticMapTestSuite {
     OrderStatisticMap<String, String> map = NaiveOrderStatisticMap.createMapWithSameOrder(testMap);
 
     testMap.remove("a");
-    Assert.assertFalse(testMap.containsKey("a"));
-    Assert.assertTrue(map.containsKey("a"));
+    assertThat(testMap).doesNotContainKey("a");
+    assertThat(map).containsKey("a");
     map.remove("bc");
-    Assert.assertTrue(testMap.containsKey("bc"));
-    Assert.assertFalse(map.containsKey("bc"));
+    assertThat(testMap).containsKey("bc");
+    assertThat(map).doesNotContainKey("bc");
   }
 }

--- a/src/org/sosy_lab/common/collect/NaiveOrderStatisticSet.java
+++ b/src/org/sosy_lab/common/collect/NaiveOrderStatisticSet.java
@@ -1,0 +1,158 @@
+/*
+ *  SoSy-Lab Common is a library of useful utilities.
+ *  This file is part of SoSy-Lab Common.
+ *
+ *  Copyright (C) 2007-2017  Dirk Beyer
+ *  All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.sosy_lab.common.collect;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ForwardingNavigableSet;
+import com.google.common.collect.Iterables;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.NavigableSet;
+import java.util.TreeSet;
+
+/**
+ * An {@link OrderStatisticSet} with naive implementations of its functions.
+ *
+ * <p>The class wraps a {@link NavigableSet} object and delegates all methods inherited from the
+ * <code>NavigableSet</code> interface to that. For the methods particular to the <code>
+ * OrderStatisticSet</code> interface, it provides naive implementations that do not guarantee any
+ * specific performance.
+ *
+ * @param <E> type of the elements of this set. See the Javadoc of {@link OrderStatisticSet} for
+ *     possible constraints on this type
+ * @see OrderStatisticSet
+ */
+final class NaiveOrderStatisticSet<E> extends ForwardingNavigableSet<E>
+    implements OrderStatisticSet<E>, Serializable {
+
+  private static final long serialVersionUID = -1941093176613766876L;
+
+  private final NavigableSet<E> delegate;
+
+  private NaiveOrderStatisticSet(NavigableSet<E> pNavigableSet) {
+    delegate = pNavigableSet;
+  }
+
+  /** Creates a new empty OrderStatisticSet using natural ordering. */
+  static <E> NaiveOrderStatisticSet<E> createSet() {
+    return new NaiveOrderStatisticSet<>(new TreeSet<>());
+  }
+
+  /** Creates a new empty OrderStatisticSet using the given comparator. */
+  static <E> NaiveOrderStatisticSet<E> createSet(Comparator<? super E> pComparator) {
+    return new NaiveOrderStatisticSet<>(new TreeSet<>(checkNotNull(pComparator)));
+  }
+
+  /**
+   * Creates a new OrderStatisticSet containing the same elements as the given collection, using
+   * natural ordering.
+   */
+  static <E> NaiveOrderStatisticSet<E> createSetWithNaturalOrder(Collection<E> pSet) {
+    return new NaiveOrderStatisticSet<>(new TreeSet<>(checkNotNull(pSet)));
+  }
+
+  /**
+   * Creates a new OrderStatisticSet containing the same elements and using the same order as the
+   * given {@link NavigableSet}.
+   *
+   * @param pNavigableSet set to use elements and ordering of
+   * @param <E> type of the elements of the given and new set
+   * @return a new OrderStatisticSet containing the same elements and using the same order as the
+   *     given set
+   */
+  static <E> NaiveOrderStatisticSet<E> createSetWithSameOrder(NavigableSet<E> pNavigableSet) {
+    return new NaiveOrderStatisticSet<>(new TreeSet<>(checkNotNull(pNavigableSet)));
+  }
+
+  @Override
+  protected NavigableSet<E> delegate() {
+    return delegate;
+  }
+
+  @Override
+  public E getByRank(int pIndex) {
+    return Iterables.get(delegate, pIndex);
+  }
+
+  @Override
+  @CanIgnoreReturnValue
+  public E removeByRank(int pIndex) {
+    E elem = getByRank(pIndex);
+    Preconditions.checkState(delegate.remove(elem), "Element could be retrieved, but not deleted");
+    return elem;
+  }
+
+  @Override
+  public int rankOf(E pObj) {
+    checkNotNull(pObj);
+    return Iterables.indexOf(delegate, o -> compare(o, pObj) == 0);
+  }
+
+  @SuppressWarnings("unchecked")
+  private int compare(E pO1, E pO2) {
+    Comparator<? super E> comparator = comparator();
+    if (comparator != null) {
+      return comparator.compare(pO1, pO2);
+    } else {
+      return ((Comparable<E>) pO1).compareTo(pO2);
+    }
+  }
+
+  @Override
+  public OrderStatisticSet<E> descendingSet() {
+    return new NaiveOrderStatisticSet<>(super.descendingSet());
+  }
+
+  @Override
+  public OrderStatisticSet<E> subSet(
+      E fromElement, boolean fromInclusive, E toElement, boolean toInclusive) {
+    return new NaiveOrderStatisticSet<>(
+        super.subSet(fromElement, fromInclusive, toElement, toInclusive));
+  }
+
+  @Override
+  public OrderStatisticSet<E> headSet(E toElement, boolean inclusive) {
+    return new NaiveOrderStatisticSet<>(super.headSet(toElement, inclusive));
+  }
+
+  @Override
+  public OrderStatisticSet<E> tailSet(E fromElement, boolean inclusive) {
+    return new NaiveOrderStatisticSet<>(super.tailSet(fromElement, inclusive));
+  }
+
+  @Override
+  public OrderStatisticSet<E> headSet(E toElement) {
+    return headSet(toElement, /* inclusive= */ false);
+  }
+
+  @Override
+  public OrderStatisticSet<E> subSet(E fromElement, E toElement) {
+    return subSet(fromElement, /* fromInclusive= */ true, toElement, /* toInclusive= */ false);
+  }
+
+  @Override
+  public OrderStatisticSet<E> tailSet(E fromElement) {
+    return tailSet(fromElement, /* inclusive= */ true);
+  }
+}

--- a/src/org/sosy_lab/common/collect/NaiveOrderStatisticSet.java
+++ b/src/org/sosy_lab/common/collect/NaiveOrderStatisticSet.java
@@ -36,8 +36,8 @@ import java.util.TreeSet;
  *
  * <p>The class wraps a {@link NavigableSet} object and delegates all methods inherited from the
  * <code>NavigableSet</code> interface to that. For the methods particular to the <code>
- * OrderStatisticSet</code> interface, it provides naive implementations that do not guarantee any
- * specific performance.
+ * OrderStatisticSet</code> interface, it provides naive implementations that guarantee
+ * performance only in O(n).
  *
  * @param <E> type of the elements of this set. See the Javadoc of {@link OrderStatisticSet} for
  *     possible constraints on this type

--- a/src/org/sosy_lab/common/collect/NaiveOrderStatisticSet.java
+++ b/src/org/sosy_lab/common/collect/NaiveOrderStatisticSet.java
@@ -26,7 +26,6 @@ import com.google.common.collect.ForwardingNavigableSet;
 import com.google.common.collect.Iterables;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.io.Serializable;
-import java.util.Collection;
 import java.util.Comparator;
 import java.util.NavigableSet;
 import java.util.SortedSet;
@@ -66,11 +65,13 @@ final class NaiveOrderStatisticSet<E> extends ForwardingNavigableSet<E>
   }
 
   /**
-   * Creates a new OrderStatisticSet containing the same elements as the given collection, using
+   * Creates a new OrderStatisticSet containing the same elements as the given Iterable, using
    * natural ordering.
    */
-  static <E> NaiveOrderStatisticSet<E> createSetWithNaturalOrder(Collection<E> pSet) {
-    return new NaiveOrderStatisticSet<>(new TreeSet<>(checkNotNull(pSet)));
+  static <E> NaiveOrderStatisticSet<E> createSetWithNaturalOrder(Iterable<E> pSet) {
+    NavigableSet<E> delegate = new TreeSet<>();
+    Iterables.addAll(delegate, pSet);
+    return new NaiveOrderStatisticSet<>(delegate);
   }
 
   /**

--- a/src/org/sosy_lab/common/collect/NaiveOrderStatisticSet.java
+++ b/src/org/sosy_lab/common/collect/NaiveOrderStatisticSet.java
@@ -29,6 +29,7 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.NavigableSet;
+import java.util.SortedSet;
 import java.util.TreeSet;
 
 /**

--- a/src/org/sosy_lab/common/collect/NaiveOrderStatisticSet.java
+++ b/src/org/sosy_lab/common/collect/NaiveOrderStatisticSet.java
@@ -37,8 +37,8 @@ import java.util.TreeSet;
  *
  * <p>The class wraps a {@link NavigableSet} object and delegates all methods inherited from the
  * <code>NavigableSet</code> interface to that. For the methods particular to the <code>
- * OrderStatisticSet</code> interface, it provides naive implementations that guarantee
- * performance only in O(n).
+ * OrderStatisticSet</code> interface, it provides naive implementations that guarantee performance
+ * only in O(n).
  *
  * @param <E> type of the elements of this set. See the Javadoc of {@link OrderStatisticSet} for
  *     possible constraints on this type
@@ -75,21 +75,21 @@ final class NaiveOrderStatisticSet<E> extends ForwardingNavigableSet<E>
 
   /**
    * Creates a new OrderStatisticSet containing the same elements and using the same order as the
-   * given {@link NavigableSet}.
+   * given {@link SortedSet}.
    *
-   * @param pNavigableSet set to use elements and ordering of
+   * @param pSortedSet set to use elements and ordering of
    * @param <E> type of the elements of the given and new set
    * @return a new OrderStatisticSet containing the same elements and using the same order as the
    *     given set
    */
-  static <E> NaiveOrderStatisticSet<E> createSetWithSameOrder(NavigableSet<E> pNavigableSet) {
-    return new NaiveOrderStatisticSet<>(new TreeSet<>(checkNotNull(pNavigableSet)));
+  static <E> NaiveOrderStatisticSet<E> createSetWithSameOrder(SortedSet<E> pSortedSet) {
+    return new NaiveOrderStatisticSet<>(new TreeSet<>(checkNotNull(pSortedSet)));
   }
 
   /**
-   * Creates a new OrderStatisticSet that is backed by the given {@link NavigableSet}.
-   * Any change to the given navigable set will be reflected by the returned OrderStatisticSet,
-   * and any change to the OrderStatisticSet will be reflected by the navigable set.
+   * Creates a new OrderStatisticSet that is backed by the given {@link NavigableSet}. Any change to
+   * the given navigable set will be reflected by the returned OrderStatisticSet, and any change to
+   * the OrderStatisticSet will be reflected by the navigable set.
    *
    * @param pNavigableSet backing navigable set
    * @param <E> type of the elements of the given set

--- a/src/org/sosy_lab/common/collect/NaiveOrderStatisticSet.java
+++ b/src/org/sosy_lab/common/collect/NaiveOrderStatisticSet.java
@@ -50,8 +50,8 @@ final class NaiveOrderStatisticSet<E> extends ForwardingNavigableSet<E>
 
   private final NavigableSet<E> delegate;
 
-  private NaiveOrderStatisticSet(NavigableSet<E> pNavigableSet) {
-    delegate = pNavigableSet;
+  private NaiveOrderStatisticSet(NavigableSet<E> pDelegate) {
+    delegate = pDelegate;
   }
 
   /** Creates a new empty OrderStatisticSet using natural ordering. */
@@ -83,6 +83,19 @@ final class NaiveOrderStatisticSet<E> extends ForwardingNavigableSet<E>
    */
   static <E> NaiveOrderStatisticSet<E> createSetWithSameOrder(NavigableSet<E> pNavigableSet) {
     return new NaiveOrderStatisticSet<>(new TreeSet<>(checkNotNull(pNavigableSet)));
+  }
+
+  /**
+   * Creates a new OrderStatisticSet that is backed by the given {@link NavigableSet}.
+   * Any change to the given navigable set will be reflected by the returned OrderStatisticSet,
+   * and any change to the OrderStatisticSet will be reflected by the navigable set.
+   *
+   * @param pNavigableSet backing navigable set
+   * @param <E> type of the elements of the given set
+   * @return a new OrderStatisticSet view on the given navigable set
+   */
+  static <E> NaiveOrderStatisticSet<E> createView(NavigableSet<E> pNavigableSet) {
+    return new NaiveOrderStatisticSet<>(checkNotNull(pNavigableSet));
   }
 
   @Override

--- a/src/org/sosy_lab/common/collect/NaiveOrderStatisticSetTest.java
+++ b/src/org/sosy_lab/common/collect/NaiveOrderStatisticSetTest.java
@@ -19,6 +19,8 @@
  */
 package org.sosy_lab.common.collect;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.testing.NavigableSetTestSuiteBuilder;
 import com.google.common.collect.testing.TestSortedSetGenerator;
@@ -30,7 +32,6 @@ import java.util.NavigableSet;
 import java.util.TreeSet;
 import junit.framework.JUnit4TestAdapter;
 import junit.framework.TestSuite;
-import org.junit.Assert;
 import org.junit.Test;
 
 public final class NaiveOrderStatisticSetTest extends OrderStatisticSetTestSuite {
@@ -81,10 +82,10 @@ public final class NaiveOrderStatisticSetTest extends OrderStatisticSetTestSuite
     OrderStatisticSet<String> set = NaiveOrderStatisticSet.createSetWithSameOrder(testCollection);
 
     testCollection.remove("a");
-    Assert.assertFalse(testCollection.contains("a"));
-    Assert.assertTrue(set.contains("a"));
+    assertThat(testCollection).doesNotContain("a");
+    assertThat(set).contains("a");
     set.remove("bc");
-    Assert.assertTrue(testCollection.contains("bc"));
-    Assert.assertFalse(set.contains("bc"));
+    assertThat(testCollection).contains("bc");
+    assertThat(set).doesNotContain("bc");
   }
 }

--- a/src/org/sosy_lab/common/collect/NaiveOrderStatisticSetTest.java
+++ b/src/org/sosy_lab/common/collect/NaiveOrderStatisticSetTest.java
@@ -1,0 +1,89 @@
+/*
+ *  SoSy-Lab Common is a library of useful utilities.
+ *  This file is part of SoSy-Lab Common.
+ *
+ *  Copyright (C) 2007-2015  Dirk Beyer
+ *  All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.sosy_lab.common.collect;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.testing.NavigableSetTestSuiteBuilder;
+import com.google.common.collect.testing.TestSortedSetGenerator;
+import com.google.common.collect.testing.features.CollectionFeature;
+import com.google.common.collect.testing.features.CollectionSize;
+import com.google.common.collect.testing.features.SetFeature;
+import java.util.Arrays;
+import java.util.NavigableSet;
+import java.util.TreeSet;
+import junit.framework.JUnit4TestAdapter;
+import junit.framework.TestSuite;
+import org.junit.Assert;
+import org.junit.Test;
+
+public final class NaiveOrderStatisticSetTest extends OrderStatisticSetTestSuite {
+
+  private static class OrderStatisticsSetProxyFactory extends OrderStatisticSetFactory {
+
+    @Override
+    protected OrderStatisticSet<String> create(String[] pStrings) {
+      NaiveOrderStatisticSet<String> list = createSet();
+      boolean changed = list.addAll(Arrays.asList(pStrings));
+      assert list.isEmpty() || changed;
+
+      return list;
+    }
+
+    private static <T> NaiveOrderStatisticSet<T> createSet() {
+      return NaiveOrderStatisticSet.createSet();
+    }
+  }
+
+  public NaiveOrderStatisticSetTest() {
+    super(new OrderStatisticsSetProxyFactory());
+  }
+
+  public static junit.framework.Test suite() {
+    TestSortedSetGenerator<String> testSetGenerator = new OrderStatisticsSetProxyFactory();
+
+    TestSuite suite =
+        NavigableSetTestSuiteBuilder.using(testSetGenerator)
+            .named("NaiveOrderStatisticSet")
+            .withFeatures(
+                CollectionSize.ANY,
+                SetFeature.GENERAL_PURPOSE,
+                CollectionFeature.KNOWN_ORDER,
+                CollectionFeature.SERIALIZABLE_INCLUDING_VIEWS,
+                CollectionFeature.SUBSET_VIEW)
+            .createTestSuite();
+
+    suite.addTest(new JUnit4TestAdapter(NaiveOrderStatisticSetTest.class));
+
+    return suite;
+  }
+
+  @Test
+  public void testNoReference() {
+    NavigableSet<String> testCollection = new TreeSet<>(ImmutableList.of("a", "b", "bc", "d"));
+    OrderStatisticSet<String> set = NaiveOrderStatisticSet.createSetWithSameOrder(testCollection);
+
+    testCollection.remove("a");
+    Assert.assertFalse(testCollection.contains("a"));
+    Assert.assertTrue(set.contains("a"));
+    set.remove("bc");
+    Assert.assertTrue(testCollection.contains("bc"));
+    Assert.assertFalse(set.contains("bc"));
+  }
+}

--- a/src/org/sosy_lab/common/collect/NaiveOrderStatisticSetTest.java
+++ b/src/org/sosy_lab/common/collect/NaiveOrderStatisticSetTest.java
@@ -66,7 +66,8 @@ public final class NaiveOrderStatisticSetTest extends OrderStatisticSetTestSuite
                 SetFeature.GENERAL_PURPOSE,
                 CollectionFeature.KNOWN_ORDER,
                 CollectionFeature.SERIALIZABLE_INCLUDING_VIEWS,
-                CollectionFeature.SUBSET_VIEW)
+                CollectionFeature.SUBSET_VIEW,
+                CollectionFeature.DESCENDING_VIEW)
             .createTestSuite();
 
     suite.addTest(new JUnit4TestAdapter(NaiveOrderStatisticSetTest.class));

--- a/src/org/sosy_lab/common/collect/OrderStatisticMap.java
+++ b/src/org/sosy_lab/common/collect/OrderStatisticMap.java
@@ -23,6 +23,7 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.NavigableMap;
+import java.util.SortedMap;
 
 /**
  * A {@link NavigableMap} that allows two additional operations: receiving (and deleting) an entry
@@ -159,17 +160,16 @@ public interface OrderStatisticMap<K, V> extends NavigableMap<K, V> {
 
   /**
    * Creates a new OrderStatisticMap containing the same entries and using the same order over keys
-   * as the given {@link NavigableMap}. The returned map guarantees performance only in O(n) for the
+   * as the given {@link SortedMap}. The returned map guarantees performance only in O(n) for the
    * operations specific to the OrderStatisticMap interface.
    *
-   * @param pNavigableMap map to use entries and ordering of
+   * @param pSortedMap map to use entries and ordering of
    * @param <K> type of the keys of the given and new map
    * @param <V> type of the values of the given and new map
    * @return a new OrderStatisticMap containing the same entries and using the same order over keys
    *     as the given map
    */
-  static <K, V> OrderStatisticMap<K, V> createWithSameOrder(
-      NavigableMap<K, ? extends V> pNavigableMap) {
-    return NaiveOrderStatisticMap.createMapWithSameOrder(pNavigableMap);
+  static <K, V> OrderStatisticMap<K, V> createWithSameOrder(SortedMap<K, ? extends V> pSortedMap) {
+    return NaiveOrderStatisticMap.createMapWithSameOrder(pSortedMap);
   }
 }

--- a/src/org/sosy_lab/common/collect/OrderStatisticMap.java
+++ b/src/org/sosy_lab/common/collect/OrderStatisticMap.java
@@ -54,12 +54,18 @@ import java.util.SortedMap;
 public interface OrderStatisticMap<K, V> extends NavigableMap<K, V> {
 
   /**
-   * Returns the element of this set with the given rank. The lowest element in the set has rank ==
-   * 0, the largest element in the set has rank == size - 1.
+   * Returns the key of this map with the given rank. The lowest key in the map has rank == 0, the
+   * largest key in the set has rank == size - 1.
    *
-   * @param pIndex the rank of the element to return
-   * @return the element of this set with the given rank
-   * @throws IndexOutOfBoundsException if the given rank is out of the range of this set (i.e.,
+   * <p>If this OrderStatisticMap is a view on some backing OrderStatisticMap (as created, e.g., by
+   * {@link #descendingMap()} or {@link #headMap(Object)}), the returned rank is in relation to the
+   * keys in the view, not in relation to the keys in the backing set. Thus, one can always expect
+   * that key of rank 0 is the first key in this map, and key of rank <code>{@link #size()} - 1
+   * </code> is the last.
+   *
+   * @param pIndex the rank of the key to return
+   * @return the key of this map with the given rank
+   * @throws IndexOutOfBoundsException if the given rank is out of the range of this map (i.e.,
    *     pRank &lt; 0 || pRank &gt;= size)
    */
   default K getKeyByRank(int pIndex) {
@@ -69,6 +75,12 @@ public interface OrderStatisticMap<K, V> extends NavigableMap<K, V> {
   /**
    * Returns the entry of this map with the given rank. The lowest entry in the set has rank == 0,
    * the largest entry in the set has rank == size - 1.
+   *
+   * <p>If this OrderStatisticMap is a view on some backing OrderStatisticMap (as created, e.g., by
+   * {@link #descendingMap()} or {@link #headMap(Object)}), the returned rank is in relation to the
+   * entries in the view, not in relation to the entries in the backing set. Thus, one can always
+   * expect that entry of rank 0 is the first entry in this map, and entry of rank <code>
+   * {@link #size()} - 1</code> is the last.
    *
    * @param pIndex the rank of the entry to return
    * @return the entry of this map with the given rank
@@ -82,6 +94,12 @@ public interface OrderStatisticMap<K, V> extends NavigableMap<K, V> {
    *
    * <p>The lowest entry in the map has rank == 0, the largest entry in the map has rank == size -
    * 1.
+   *
+   * <p>If this OrderStatisticMap is a view on some backing OrderStatisticMap (as created, e.g., by
+   * {@link #descendingMap()} or {@link #headMap(Object)}), the returned rank is in relation to the
+   * entries in the view, not in relation to the entries in the backing set. Thus, one can always
+   * expect that entry of rank 0 is the first entry in this map, and entry of rank <code>
+   * {@link #size()} - 1</code> is the last.
    *
    * @param pIndex the rank of the element to remove
    * @return the removed element
@@ -98,6 +116,12 @@ public interface OrderStatisticMap<K, V> extends NavigableMap<K, V> {
    *
    * <p>The lowest entry in the set has rank == 0, the largest entry in the set has rank == size -
    * 1.
+   *
+   * <p>If this OrderStatisticMap is a view on some backing OrderStatisticMap (as created, e.g., by
+   * {@link #descendingMap()} or {@link #headMap(Object)}), the returned rank is in relation to the
+   * entries in the view, not in relation to the entries in the backing set. Thus, one can always
+   * expect that key of rank 0 is the first key in this map, and key of rank <code>
+   * {@link #size()} - 1</code> is the last.
    *
    * @param pObj the key of the entry to return the rank for
    * @return the rank of the entry with the given key in the map, or -1 if the key is not in the set

--- a/src/org/sosy_lab/common/collect/OrderStatisticMap.java
+++ b/src/org/sosy_lab/common/collect/OrderStatisticMap.java
@@ -61,7 +61,9 @@ public interface OrderStatisticMap<K, V> extends NavigableMap<K, V> {
    * @throws IndexOutOfBoundsException if the given rank is out of the range of this set (i.e.,
    *     pRank &lt; 0 || pRank &gt;= size)
    */
-  K getKeyByRank(int pIndex);
+  default K getKeyByRank(int pIndex) {
+    return getEntryByRank(pIndex).getKey();
+  }
 
   /**
    * Returns the entry of this map with the given rank. The lowest entry in the set has rank == 0,

--- a/src/org/sosy_lab/common/collect/OrderStatisticMap.java
+++ b/src/org/sosy_lab/common/collect/OrderStatisticMap.java
@@ -24,6 +24,32 @@ import java.util.Comparator;
 import java.util.Map;
 import java.util.NavigableMap;
 
+/**
+ * A {@link NavigableMap} that allows two additional operations: receiving (and deleting) an entry
+ * by its <i>rank</i>, and getting the rank of an entry.
+ *
+ * <p>Implementations should adhere to all contracts of the <code>NavigableMap</code> interface.
+ *
+ * <p>Implementing classes should provide two means for comparing elements:
+ *
+ * <ol>
+ *   <li>Using the natural ordering over the keys. In this case, all keys of the map have to
+ *       implement the {@link Comparable} interface.
+ *   <li>Using a {@link java.util.Comparator Comparator} to create an order over the keys of the
+ *       map.
+ * </ol>
+ *
+ * <p>In both cases, the used compare-method should be consistent with <code>equals</code>, i.e.,
+ * <code>compare(k, l) == 0  =&gt;  k.equals(l)</code>, so that the {@link java.util.Map Map}
+ * interface is correctly implemented. If the used compare-method is not consistent with <code>
+ * equals</code>, the Map contract is not fulfilled (See the {@link java.util.SortedMap SortedMap}
+ * interface for a more detailed description).
+ *
+ * @param <K> the type of the keys of this map
+ * @param <V> the type of the values of this map
+ * @see java.util.Map
+ * @see java.util.SortedMap
+ */
 public interface OrderStatisticMap<K, V> extends NavigableMap<K, V> {
 
   /**
@@ -103,19 +129,27 @@ public interface OrderStatisticMap<K, V> extends NavigableMap<K, V> {
   @Override
   OrderStatisticMap<K, V> tailMap(K fromKey);
 
-  /** Creates a new empty OrderStatisticMap using natural ordering. */
+  /**
+   * Creates a new empty OrderStatisticMap using natural ordering. The returned map guarantees
+   * performance only in O(n) for the operations specific to the OrderStatisticMap interface.
+   */
   static <K, V> OrderStatisticMap<K, V> create() {
     return NaiveOrderStatisticMap.createMap();
   }
 
-  /** Creates a new empty OrderStatisticMap using the given comparator over its keys. */
+  /**
+   * Creates a new empty OrderStatisticMap using the given comparator over its keys. The returned
+   * map guarantees performance only in O(n) for the operations specific to the OrderStatisticMap
+   * interface.
+   */
   static <K, V> OrderStatisticMap<K, V> create(Comparator<? super K> pComparator) {
     return NaiveOrderStatisticMap.createMap(pComparator);
   }
 
   /**
    * Creates a new OrderStatisticSet containing the same entries as the given map, using natural
-   * ordering over its keys.
+   * ordering over its keys. The returned map guarantees performance only in O(n) for the operations
+   * specific to the OrderStatisticMap interface.
    */
   static <K, V> OrderStatisticMap<K, V> createWithNaturalOrder(Map<? extends K, ? extends V> pMap) {
     return NaiveOrderStatisticMap.createMapWithNaturalOrder(pMap);
@@ -123,7 +157,8 @@ public interface OrderStatisticMap<K, V> extends NavigableMap<K, V> {
 
   /**
    * Creates a new OrderStatisticMap containing the same entries and using the same order over keys
-   * as the given {@link NavigableMap}.
+   * as the given {@link NavigableMap}. The returned map guarantees performance only in O(n) for the
+   * operations specific to the OrderStatisticMap interface.
    *
    * @param pNavigableMap map to use entries and ordering of
    * @param <K> type of the keys of the given and new map

--- a/src/org/sosy_lab/common/collect/OrderStatisticMap.java
+++ b/src/org/sosy_lab/common/collect/OrderStatisticMap.java
@@ -1,0 +1,138 @@
+/*
+ *  SoSy-Lab Common is a library of useful utilities.
+ *  This file is part of SoSy-Lab Common.
+ *
+ *  Copyright (C) 2007-2017  Dirk Beyer
+ *  All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.sosy_lab.common.collect;
+
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.NavigableMap;
+
+public interface OrderStatisticMap<K, V> extends NavigableMap<K, V> {
+
+  /**
+   * Returns the element of this set with the given rank. The lowest element in the set has rank ==
+   * 0, the largest element in the set has rank == size - 1.
+   *
+   * @param pIndex the rank of the element to return
+   * @return the element of this set with the given rank
+   * @throws IndexOutOfBoundsException if the given rank is out of the range of this set (i.e.,
+   *     pRank &lt; 0 || pRank &gt;= size)
+   */
+  K getKeyByRank(int pIndex);
+
+  /**
+   * Returns the entry of this map with the given rank. The lowest entry in the set has rank == 0,
+   * the largest entry in the set has rank == size - 1.
+   *
+   * @param pIndex the rank of the entry to return
+   * @return the entry of this map with the given rank
+   * @throws IndexOutOfBoundsException if the given rank is out of the range of this map (i.e.,
+   *     pRank &lt; 0 || pRank &gt;= size)
+   */
+  Map.Entry<K, V> getEntryByRank(int pIndex);
+
+  /**
+   * Remove the entry of this map with the given rank and return its key.
+   *
+   * <p>The lowest entry in the map has rank == 0, the largest entry in the map has rank == size -
+   * 1.
+   *
+   * @param pIndex the rank of the element to remove
+   * @return the removed element
+   * @throws IndexOutOfBoundsException if the given rank is out of the range of this set (i.e.,
+   *     pRank &lt; 0 || pRank &gt;= size)
+   * @see #getKeyByRank(int)
+   */
+  @CanIgnoreReturnValue
+  K removeByRank(int pIndex);
+
+  /**
+   * Return the rank of the entry with the given key in this map. Returns -1 if the key does not
+   * exist in the map.
+   *
+   * <p>The lowest entry in the set has rank == 0, the largest entry in the set has rank == size -
+   * 1.
+   *
+   * @param pObj the key of the entry to return the rank for
+   * @return the rank of the entry with the given key in the map, or -1 if the key is not in the set
+   * @throws NullPointerException if the given key is <code>null</code>
+   */
+  int rankOf(K pObj);
+
+  @Override
+  OrderStatisticMap<K, V> descendingMap();
+
+  @Override
+  OrderStatisticSet<K> navigableKeySet();
+
+  @Override
+  OrderStatisticSet<K> descendingKeySet();
+
+  @Override
+  OrderStatisticMap<K, V> subMap(K fromKey, boolean fromInclusive, K toKey, boolean toInclusive);
+
+  @Override
+  OrderStatisticMap<K, V> headMap(K toKey, boolean inclusive);
+
+  @Override
+  OrderStatisticMap<K, V> tailMap(K fromKey, boolean inclusive);
+
+  @Override
+  OrderStatisticMap<K, V> subMap(K fromKey, K toKey);
+
+  @Override
+  OrderStatisticMap<K, V> headMap(K toKey);
+
+  @Override
+  OrderStatisticMap<K, V> tailMap(K fromKey);
+
+  /** Creates a new empty OrderStatisticMap using natural ordering. */
+  static <K, V> OrderStatisticMap<K, V> create() {
+    return NaiveOrderStatisticMap.createMap();
+  }
+
+  /** Creates a new empty OrderStatisticMap using the given comparator over its keys. */
+  static <K, V> OrderStatisticMap<K, V> create(Comparator<? super K> pComparator) {
+    return NaiveOrderStatisticMap.createMap(pComparator);
+  }
+
+  /**
+   * Creates a new OrderStatisticSet containing the same entries as the given map, using natural
+   * ordering over its keys.
+   */
+  static <K, V> OrderStatisticMap<K, V> createWithNaturalOrder(Map<? extends K, ? extends V> pMap) {
+    return NaiveOrderStatisticMap.createMapWithNaturalOrder(pMap);
+  }
+
+  /**
+   * Creates a new OrderStatisticMap containing the same entries and using the same order over keys
+   * as the given {@link NavigableMap}.
+   *
+   * @param pNavigableMap map to use entries and ordering of
+   * @param <K> type of the keys of the given and new map
+   * @param <V> type of the values of the given and new map
+   * @return a new OrderStatisticMap containing the same entries and using the same order over keys
+   *     as the given map
+   */
+  static <K, V> OrderStatisticMap<K, V> createWithSameOrder(
+      NavigableMap<K, ? extends V> pNavigableMap) {
+    return NaiveOrderStatisticMap.createMapWithSameOrder(pNavigableMap);
+  }
+}

--- a/src/org/sosy_lab/common/collect/OrderStatisticMapTestSuite.java
+++ b/src/org/sosy_lab/common/collect/OrderStatisticMapTestSuite.java
@@ -257,6 +257,15 @@ public abstract class OrderStatisticMapTestSuite {
   }
 
   @Test
+  public void testKeyset_mutation() {
+    OrderStatisticMap<String, String> map = createMap(ELEMS);
+    OrderStatisticSet<String> keySet = map.navigableKeySet();
+
+    keySet.removeByRank(0);
+    Assert.assertFalse(map.containsKey(ELEMS.get(0).getKey()));
+  }
+
+  @Test
   public void testSubmapView_submapOfSubmap() {
     OrderStatisticMap<String, String> map = createMap(ELEMS);
     NavigableMap<String, String> subMap =

--- a/src/org/sosy_lab/common/collect/OrderStatisticMapTestSuite.java
+++ b/src/org/sosy_lab/common/collect/OrderStatisticMapTestSuite.java
@@ -177,18 +177,20 @@ public abstract class OrderStatisticMapTestSuite {
       putEntry(subMap, ELEMS.get(0));
       fail();
     } catch (IllegalArgumentException expected) {
-      try {
-        putEntry(subMap, ELEMS.get(3));
-        fail();
-      } catch (IllegalArgumentException expected2) {
-        try {
-          // the first 3 elements are in the range of the sublist, but the last isn't
-          subMap.putAll(toAdd);
-          fail();
-        } catch (IllegalArgumentException expected3) {
-          // expected outcome
-        }
-      }
+      // expected outcome
+    }
+    try {
+      putEntry(subMap, ELEMS.get(3));
+      fail();
+    } catch (IllegalArgumentException expected) {
+      // expected outcome
+    }
+    try {
+      // the first 3 elements are in the range of the sublist, but the last isn't
+      subMap.putAll(toAdd);
+      fail();
+    } catch (IllegalArgumentException expected) {
+      // expected outcome
     }
   }
 
@@ -326,12 +328,13 @@ public abstract class OrderStatisticMapTestSuite {
       map.getEntryByRank(-1);
       fail("Expected " + IndexOutOfBoundsException.class.getSimpleName());
     } catch (IndexOutOfBoundsException expected) {
-      try {
-        map.getEntryByRank(ELEMS.size());
-        fail("Expected " + IndexOutOfBoundsException.class.getSimpleName());
-      } catch (IndexOutOfBoundsException expected2) {
-        // expected outcome
-      }
+      // expected outcome
+    }
+    try {
+      map.getEntryByRank(ELEMS.size());
+      fail("Expected " + IndexOutOfBoundsException.class.getSimpleName());
+    } catch (IndexOutOfBoundsException expected) {
+      // expected outcome
     }
   }
 
@@ -413,12 +416,13 @@ public abstract class OrderStatisticMapTestSuite {
       map.getKeyByRank(-1);
       fail("Expected " + IndexOutOfBoundsException.class.getSimpleName());
     } catch (IndexOutOfBoundsException expected) {
-      try {
-        map.getKeyByRank(ELEMS.size());
-        fail("Expected " + IndexOutOfBoundsException.class.getSimpleName());
-      } catch (IndexOutOfBoundsException expected2) {
-        // expected outcome
-      }
+      // expected outcome
+    }
+    try {
+      map.getKeyByRank(ELEMS.size());
+      fail("Expected " + IndexOutOfBoundsException.class.getSimpleName());
+    } catch (IndexOutOfBoundsException expected) {
+      // expected outcome
     }
   }
 
@@ -518,17 +522,20 @@ public abstract class OrderStatisticMapTestSuite {
       map.removeByRank(-1);
       fail();
     } catch (IndexOutOfBoundsException expected) {
-      try {
-        map.removeByRank(map.size());
-        fail();
-      } catch (IndexOutOfBoundsException expected2) {
-        try {
-          emptyMap.removeByRank(0);
-          fail();
-        } catch (IndexOutOfBoundsException expected3) {
-          // expected outcome
-        }
-      }
+      // expected outcome
+    }
+    try {
+      map.removeByRank(map.size());
+      fail();
+    } catch (IndexOutOfBoundsException expected) {
+      // expected outcome
+    }
+    try {
+      emptyMap.removeByRank(0);
+      fail();
+    } catch (IndexOutOfBoundsException expected) {
+      // expected outcome
+
     }
   }
 

--- a/src/org/sosy_lab/common/collect/OrderStatisticMapTestSuite.java
+++ b/src/org/sosy_lab/common/collect/OrderStatisticMapTestSuite.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.testing.TestStringSortedMapGenerator;
+import com.google.common.testing.EqualsTester;
 import com.google.common.testing.SerializableTester;
 import com.google.errorprone.annotations.Var;
 import java.util.Collections;
@@ -96,28 +97,33 @@ public abstract class OrderStatisticMapTestSuite {
 
   @Test
   public void testEquals() {
-    OrderStatisticMap<String, String> l1 = createMap();
+    EqualsTester mapEqualsTester = new EqualsTester();
+    @Var OrderStatisticMap<String, String> l1 = createMap();
     @Var OrderStatisticMap<String, String> l2 = createMap();
 
+    mapEqualsTester.addEqualityGroup(l1, l2);
+
+    l1 = createMap();
+    l2 = createMap();
     // Check that the map sorts its elements
-    Assert.assertEquals(l1, l2);
     for (int i = ELEMS.size() - 1; i >= 0; i--) {
       l2.put(ELEMS.get(i).getKey(), ELEMS.get(i).getValue());
     }
     for (int i = 0; i < ELEMS.size(); i++) {
       l1.put(ELEMS.get(i).getKey(), ELEMS.get(i).getValue());
     }
-    Assert.assertEquals(l1, l2);
 
     // Check the map property
-    l2 = createMap();
+    @Var OrderStatisticMap<String, String> l3 = createMap();
     for (int i = ELEMS.size() - 1; i >= 0; i--) {
-      l2.put(ELEMS.get(i).getKey(), ELEMS.get(i).getValue());
+      l3.put(ELEMS.get(i).getKey(), ELEMS.get(i).getValue());
     }
     for (int i = 0; i < ELEMS.size(); i++) {
-      l2.put(ELEMS.get(i).getKey(), ELEMS.get(i).getValue());
+      l3.put(ELEMS.get(i).getKey(), ELEMS.get(i).getValue());
     }
-    Assert.assertEquals(l1, l2);
+    mapEqualsTester.addEqualityGroup(l1, l2, l3);
+
+    mapEqualsTester.testEquals();
   }
 
   @Test

--- a/src/org/sosy_lab/common/collect/OrderStatisticMapTestSuite.java
+++ b/src/org/sosy_lab/common/collect/OrderStatisticMapTestSuite.java
@@ -35,7 +35,6 @@ import org.junit.Test;
 
 public abstract class OrderStatisticMapTestSuite {
 
-  @SuppressWarnings("unchecked")
   private static final ImmutableList<Entry<String, String>> ELEMS =
       ImmutableList.<Entry<String, String>>builder()
           .add(Maps.immutableEntry("aaa", "Vzza"))
@@ -44,7 +43,6 @@ public abstract class OrderStatisticMapTestSuite {
           .add(Maps.immutableEntry("zza", "Vaaa"))
           .build();
 
-  @SuppressWarnings("unchecked")
   private static final ImmutableList<Entry<String, String>> ELEMS_ABOVE =
       ImmutableList.<Entry<String, String>>builder()
           .add(Maps.immutableEntry("aab", "Vzzb"))
@@ -53,7 +51,6 @@ public abstract class OrderStatisticMapTestSuite {
           .add(Maps.immutableEntry("zzb", "Vaab"))
           .build();
 
-  @SuppressWarnings("unchecked")
   private static final ImmutableList<Entry<String, String>> ELEMS_BELOW =
       ImmutableList.<Entry<String, String>>builder()
           .add(Maps.immutableEntry("aa", "Vzz"))
@@ -77,12 +74,10 @@ public abstract class OrderStatisticMapTestSuite {
     factory = pFactory;
   }
 
-  @SuppressWarnings("unchecked")
   private OrderStatisticMap<String, String> createMap() {
     return factory.create(Collections.emptyList());
   }
 
-  @SuppressWarnings("unchecked")
   private OrderStatisticMap<String, String> createMap(List<Entry<String, String>> pEntries) {
     return factory.create(pEntries);
   }

--- a/src/org/sosy_lab/common/collect/OrderStatisticMapTestSuite.java
+++ b/src/org/sosy_lab/common/collect/OrderStatisticMapTestSuite.java
@@ -19,6 +19,9 @@
  */
 package org.sosy_lab.common.collect;
 
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
@@ -31,7 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NavigableMap;
-import org.junit.Assert;
 import org.junit.Test;
 
 public abstract class OrderStatisticMapTestSuite {
@@ -83,16 +85,12 @@ public abstract class OrderStatisticMapTestSuite {
     return factory.create(pEntries);
   }
 
-  private static <K, V> boolean containsEntry(Map<K, V> pMap, Entry<K, V> pEntry) {
-    return pMap.containsKey(pEntry.getKey()) && pEntry.getValue().equals(pMap.get(pEntry.getKey()));
-  }
-
   private static <K, V> void putEntry(Map<K, V> pMap, Entry<K, V> pEntry) {
     pMap.put(pEntry.getKey(), pEntry.getValue());
   }
 
   private static <K, V> void removeEntry(Map<K, V> pMap, Entry<K, V> pEntry) {
-    Assert.assertEquals(pMap.get(pEntry.getKey()), pMap.remove(pEntry.getKey()));
+    assertThat(pMap.get(pEntry.getKey())).isEqualTo(pMap.remove(pEntry.getKey()));
   }
 
   @Test
@@ -146,21 +144,21 @@ public abstract class OrderStatisticMapTestSuite {
     Entry<String, String> toAdd = ELEMS_BELOW.get(2);
 
     putEntry(subMap, toAdd);
-    Assert.assertTrue(containsEntry(subMap, toAdd));
-    Assert.assertTrue(containsEntry(map, toAdd));
+    assertThat(subMap).containsEntry(toAdd.getKey(), toAdd.getValue());
+    assertThat(map).containsEntry(toAdd.getKey(), toAdd.getValue());
 
     removeEntry(subMap, toAdd);
-    Assert.assertFalse(map.containsKey(toAdd.getKey()));
-    Assert.assertFalse(subMap.containsKey(toAdd.getKey()));
+    assertThat(map).doesNotContainKey(toAdd.getKey());
+    assertThat(subMap).doesNotContainKey(toAdd.getKey());
 
     putEntry(map, toAdd);
-    Assert.assertTrue(containsEntry(subMap, toAdd));
+    assertThat(subMap).containsEntry(toAdd.getKey(), toAdd.getValue());
 
     removeEntry(map, toAdd);
-    Assert.assertFalse(containsEntry(subMap, toAdd));
+    assertThat(subMap).doesNotContainEntry(toAdd.getKey(), toAdd.getValue());
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testSubmapView_outOfBounds_add() {
     NavigableMap<String, String> map = createMap(ELEMS);
     NavigableMap<String, String> subMap =
@@ -168,21 +166,28 @@ public abstract class OrderStatisticMapTestSuite {
             ELEMS_ABOVE.get(0).getKey(), true,
             ELEMS_ABOVE.get(2).getKey(), true);
 
+    Map<String, String> toAdd =
+        ImmutableMap.<String, String>builder()
+            .put(ELEMS.get(1))
+            .put(ELEMS_BELOW.get(2))
+            .put(ELEMS.get(2))
+            .put(ELEMS_ABOVE.get(3))
+            .build();
     try {
       putEntry(subMap, ELEMS.get(0));
-    } catch (IllegalArgumentException e1) {
+      fail();
+    } catch (IllegalArgumentException expected) {
       try {
         putEntry(subMap, ELEMS.get(3));
-      } catch (IllegalArgumentException e2) {
-        // the first 3 elements are in the range of the sublist, but the last isn't
-        Map<String, String> toAdd =
-            ImmutableMap.<String, String>builder()
-                .put(ELEMS.get(1))
-                .put(ELEMS_BELOW.get(2))
-                .put(ELEMS.get(2))
-                .put(ELEMS_ABOVE.get(3))
-                .build();
-        subMap.putAll(toAdd);
+        fail();
+      } catch (IllegalArgumentException expected2) {
+        try {
+          // the first 3 elements are in the range of the sublist, but the last isn't
+          subMap.putAll(toAdd);
+          fail();
+        } catch (IllegalArgumentException expected3) {
+          // expected outcome
+        }
       }
     }
   }
@@ -198,8 +203,8 @@ public abstract class OrderStatisticMapTestSuite {
     removeEntry(subMap, ELEMS.get(1));
     removeEntry(subMap, ELEMS.get(3));
 
-    Assert.assertTrue(containsEntry(map, ELEMS.get(1)));
-    Assert.assertTrue(containsEntry(map, ELEMS.get(3)));
+    assertThat(map).containsEntry(ELEMS.get(1).getKey(), ELEMS.get(1).getValue());
+    assertThat(map).containsEntry(ELEMS.get(3).getKey(), ELEMS.get(3).getValue());
 
     Map<String, String> toRemove =
         ImmutableMap.<String, String>builder()
@@ -211,9 +216,9 @@ public abstract class OrderStatisticMapTestSuite {
       removeEntry(subMap, e);
     }
 
-    Assert.assertTrue(containsEntry(map, ELEMS.get(1)));
-    Assert.assertFalse(containsEntry(map, ELEMS_BELOW.get(2)));
-    Assert.assertFalse(containsEntry(map, ELEMS.get(2)));
+    assertThat(map).containsEntry(ELEMS.get(1).getKey(), ELEMS.get(1).getValue());
+    assertThat(map).doesNotContainEntry(ELEMS_BELOW.get(2).getKey(), ELEMS_BELOW.get(2).getValue());
+    assertThat(map).doesNotContainEntry(ELEMS.get(2).getKey(), ELEMS.get(2).getValue());
   }
 
   @Test
@@ -225,18 +230,20 @@ public abstract class OrderStatisticMapTestSuite {
             ELEMS_ABOVE.get(1).getKey(), true,
             ELEMS_ABOVE.get(2).getKey(), true);
 
-    Assert.assertFalse(containsEntry(subMap, ELEMS.get(1)));
-    Assert.assertFalse(containsEntry(subMap, ELEMS.get(3)));
+    assertThat(subMap).doesNotContainEntry(ELEMS.get(1).getKey(), ELEMS.get(1).getValue());
+    assertThat(subMap).doesNotContainEntry(ELEMS.get(3).getKey(), ELEMS.get(3).getValue());
 
     subMap = map.subMap(ELEMS_ABOVE.get(1).getKey(), false, ELEMS_ABOVE.get(2).getKey(), false);
 
-    Assert.assertFalse(containsEntry(subMap, ELEMS_ABOVE.get(1)));
-    Assert.assertFalse(containsEntry(subMap, ELEMS_ABOVE.get(2)));
+    assertThat(subMap)
+        .doesNotContainEntry(ELEMS_ABOVE.get(1).getKey(), ELEMS_ABOVE.get(1).getValue());
+    assertThat(subMap)
+        .doesNotContainEntry(ELEMS_ABOVE.get(2).getKey(), ELEMS_ABOVE.get(2).getValue());
 
     subMap = map.subMap(ELEMS_ABOVE.get(0).getKey(), true, ELEMS_ABOVE.get(2).getKey(), true);
 
-    Assert.assertTrue(containsEntry(subMap, ELEMS.get(1)));
-    Assert.assertTrue(containsEntry(subMap, ELEMS.get(2)));
+    assertThat(subMap).containsEntry(ELEMS.get(1).getKey(), ELEMS.get(1).getValue());
+    assertThat(subMap).containsEntry(ELEMS.get(2).getKey(), ELEMS.get(2).getValue());
   }
 
   @Test
@@ -249,12 +256,12 @@ public abstract class OrderStatisticMapTestSuite {
                 ELEMS.get(2).getKey(), /* toInclusive= */ true)
             .descendingMap();
 
-    Assert.assertEquals(ELEMS.get(2), subMap.firstEntry());
-    Assert.assertEquals(ELEMS.get(1), subMap.lastEntry());
+    assertThat(ELEMS.get(2)).isEqualTo(subMap.firstEntry());
+    assertThat(ELEMS.get(1)).isEqualTo(subMap.lastEntry());
 
     subMap = subMap.descendingMap();
-    Assert.assertEquals(ELEMS.get(1), subMap.firstEntry());
-    Assert.assertEquals(ELEMS.get(2), subMap.lastEntry());
+    assertThat(ELEMS.get(1)).isEqualTo(subMap.firstEntry());
+    assertThat(ELEMS.get(2)).isEqualTo(subMap.lastEntry());
   }
 
   @Test
@@ -263,7 +270,7 @@ public abstract class OrderStatisticMapTestSuite {
     OrderStatisticSet<String> keySet = map.navigableKeySet();
 
     keySet.removeByRank(0);
-    Assert.assertFalse(map.containsKey(ELEMS.get(0).getKey()));
+    assertThat(map).doesNotContainKey(ELEMS.get(0).getKey());
   }
 
   @Test
@@ -279,51 +286,202 @@ public abstract class OrderStatisticMapTestSuite {
             ELEMS.get(1).getKey(), /* fromInclusive= */ true,
             ELEMS_BELOW.get(3).getKey(), /* toInclusive= */ true);
 
-    Assert.assertFalse(containsEntry(subSubMap, ELEMS.get(0)));
-    Assert.assertTrue(containsEntry(subSubMap, ELEMS.get(1)));
-    Assert.assertTrue(containsEntry(subSubMap, ELEMS.get(2)));
-    Assert.assertFalse(containsEntry(subSubMap, ELEMS.get(3)));
+    assertThat(subSubMap).doesNotContainEntry(ELEMS.get(0).getKey(), ELEMS.get(0).getValue());
+    assertThat(subSubMap).containsEntry(ELEMS.get(1).getKey(), ELEMS.get(1).getValue());
+    assertThat(subSubMap).containsEntry(ELEMS.get(2).getKey(), ELEMS.get(2).getValue());
+    assertThat(subSubMap).doesNotContainEntry(ELEMS.get(3).getKey(), ELEMS.get(3).getValue());
 
     // make sure that the inclusive-flags are respected
     subSubMap =
         subMap.subMap(
             ELEMS.get(1).getKey(), /* fromInclusive= */ true,
             ELEMS.get(3).getKey(), /* toInclusive=*/ true);
-    Assert.assertTrue(containsEntry(subSubMap, ELEMS.get(1)));
-    Assert.assertTrue(containsEntry(subSubMap, ELEMS.get(2)));
-    Assert.assertTrue(containsEntry(subSubMap, ELEMS.get(3)));
+    assertThat(subSubMap).containsEntry(ELEMS.get(1).getKey(), ELEMS.get(1).getValue());
+    assertThat(subSubMap).containsEntry(ELEMS.get(2).getKey(), ELEMS.get(2).getValue());
+    assertThat(subSubMap).containsEntry(ELEMS.get(3).getKey(), ELEMS.get(3).getValue());
 
     subSubMap =
         subSubMap.subMap(
             ELEMS.get(1).getKey(), /* fromInclusive= */ false,
             ELEMS.get(3).getKey(), /* toInclusive= */ false);
-    Assert.assertFalse(containsEntry(subSubMap, ELEMS.get(1)));
-    Assert.assertTrue(containsEntry(subSubMap, ELEMS.get(2)));
-    Assert.assertFalse(containsEntry(subSubMap, ELEMS.get(3)));
+    assertThat(subSubMap).doesNotContainEntry(ELEMS.get(1).getKey(), ELEMS.get(1).getValue());
+    assertThat(subSubMap).containsEntry(ELEMS.get(2).getKey(), ELEMS.get(2).getValue());
+    assertThat(subSubMap).doesNotContainEntry(ELEMS.get(3).getKey(), ELEMS.get(3).getValue());
   }
 
   @Test
-  public void testGetByRank_valid() {
+  public void testGetEntryByRank_valid() {
     OrderStatisticMap<String, String> map = createMap(ELEMS);
 
     for (int i = 0; i < ELEMS.size(); i++) {
-      Assert.assertEquals(ELEMS.get(i), map.getEntryByRank(i));
+      assertThat(ELEMS.get(i)).isEqualTo(map.getEntryByRank(i));
     }
   }
 
-  @Test(expected = IndexOutOfBoundsException.class)
-  public void testGetByRank_outOfBounds() {
+  @Test
+  public void testGetEntryByRank_outOfBounds() {
     OrderStatisticMap<String, String> map = createMap(ELEMS);
 
     try {
-      Entry<?, ?> x = map.getEntryByRank(-1);
-      Assert.assertFalse(x != null);
-      Assert.fail("Expected " + IndexOutOfBoundsException.class.getSimpleName());
-    } catch (IndexOutOfBoundsException e) {
-      Entry<?, ?> x = map.getEntryByRank(ELEMS.size());
-      Assert.assertFalse(x != null);
-      Assert.fail("Expected " + IndexOutOfBoundsException.class.getSimpleName());
+      map.getEntryByRank(-1);
+      fail("Expected " + IndexOutOfBoundsException.class.getSimpleName());
+    } catch (IndexOutOfBoundsException expected) {
+      try {
+        map.getEntryByRank(ELEMS.size());
+        fail("Expected " + IndexOutOfBoundsException.class.getSimpleName());
+      } catch (IndexOutOfBoundsException expected2) {
+        // expected outcome
+      }
     }
+  }
+
+  @Test
+  public void testGetEntryByRank_submapFirst() {
+    OrderStatisticMap<String, String> map = createMap(ELEMS);
+    Entry<String, String> submapStart = ELEMS.get(1);
+    String firstSubmapKey = submapStart.getKey();
+    String submapEndKey = ELEMS.get(2).getKey();
+    OrderStatisticMap<String, String> subMap =
+        map.subMap(
+            firstSubmapKey, /* fromInclusive= */ true, submapEndKey, /* toInclusive= */ true);
+
+    Entry<String, String> firstSubmapEntry = subMap.getEntryByRank(0);
+
+    assertThat(firstSubmapEntry).isEqualTo(submapStart);
+  }
+
+  @Test
+  public void testGetEntryByRank_submapLast() {
+    OrderStatisticMap<String, String> map = createMap(ELEMS);
+    Entry<String, String> submapStart = ELEMS.get(1);
+    String firstSubmapKey = submapStart.getKey();
+    String submapEndKey = ELEMS.get(2).getKey();
+    OrderStatisticMap<String, String> subMap =
+        map.subMap(
+            firstSubmapKey, /* fromInclusive= */ true, submapEndKey, /* toInclusive= */ true);
+
+    Entry<String, String> lastSubmapEntry = subMap.getEntryByRank(subMap.size() - 1);
+
+    assertThat(lastSubmapEntry).isEqualTo(ELEMS.get(2));
+  }
+
+  @Test
+  public void testGetEntryByRank_descendingMapFirstElement() {
+    OrderStatisticMap<String, String> map = createMap(ELEMS);
+    OrderStatisticMap<String, String> descendingMap = map.descendingMap();
+
+    Entry<String, String> firstEntryDescending = descendingMap.getEntryByRank(0);
+
+    assertThat(firstEntryDescending).isEqualTo(ELEMS.get(ELEMS.size() - 1));
+  }
+
+  @Test
+  public void testGetEntryByRank_descendingMapSecondElement() {
+    OrderStatisticMap<String, String> map = createMap(ELEMS);
+    OrderStatisticMap<String, String> descendingMap = map.descendingMap();
+
+    Entry<String, String> sndEntryDescending = descendingMap.getEntryByRank(1);
+
+    assertThat(sndEntryDescending).isEqualTo(ELEMS.get(ELEMS.size() - 2));
+  }
+
+  @Test
+  public void testGetEntryByRank_descendingMapLastElement() {
+    OrderStatisticMap<String, String> map = createMap(ELEMS);
+    OrderStatisticMap<String, String> descendingMap = map.descendingMap();
+
+    Entry<String, String> lastEntryDescending =
+        descendingMap.getEntryByRank(descendingMap.size() - 1);
+
+    assertThat(lastEntryDescending).isEqualTo(ELEMS.get(0));
+  }
+
+  @Test
+  public void testGetKeyByRank_valid() {
+    OrderStatisticMap<String, String> map = createMap(ELEMS);
+
+    for (int i = 0; i < ELEMS.size(); i++) {
+      assertThat(ELEMS.get(i).getKey()).isEqualTo(map.getKeyByRank(i));
+    }
+  }
+
+  @Test
+  public void testGetKeyByRank_outOfBounds() {
+    OrderStatisticMap<String, String> map = createMap(ELEMS);
+
+    try {
+      map.getKeyByRank(-1);
+      fail("Expected " + IndexOutOfBoundsException.class.getSimpleName());
+    } catch (IndexOutOfBoundsException expected) {
+      try {
+        map.getKeyByRank(ELEMS.size());
+        fail("Expected " + IndexOutOfBoundsException.class.getSimpleName());
+      } catch (IndexOutOfBoundsException expected2) {
+        // expected outcome
+      }
+    }
+  }
+
+  @Test
+  public void testGetKeyByRank_submapFirst() {
+    OrderStatisticMap<String, String> map = createMap(ELEMS);
+    Entry<String, String> submapStart = ELEMS.get(1);
+    String submapStartKey = submapStart.getKey();
+    String submapEnd = ELEMS.get(2).getKey();
+    OrderStatisticMap<String, String> subMap =
+        map.subMap(submapStartKey, /* fromInclusive= */ true, submapEnd, /* toInclusive= */ true);
+
+    String firstSubmapKey = subMap.getKeyByRank(0);
+
+    assertThat(firstSubmapKey).isEqualTo(submapStartKey);
+  }
+
+  @Test
+  public void testGetKeyByRank_submapLast() {
+    OrderStatisticMap<String, String> map = createMap(ELEMS);
+    Entry<String, String> submapStart = ELEMS.get(1);
+    String submapStartKey = submapStart.getKey();
+    String submapEndKey = ELEMS.get(2).getKey();
+    OrderStatisticMap<String, String> subMap =
+        map.subMap(
+            submapStartKey, /* fromInclusive= */ true, submapEndKey, /* toInclusive= */ true);
+
+    String lastSubmapKey = subMap.getKeyByRank(subMap.size() - 1);
+
+    assertThat(lastSubmapKey).isEqualTo(submapEndKey);
+  }
+
+  @Test
+  public void testGetKeyByRank_descendingMapFirstElement() {
+    OrderStatisticMap<String, String> map = createMap(ELEMS);
+    OrderStatisticMap<String, String> descendingMap = map.descendingMap();
+    String expectedKey = ELEMS.get(ELEMS.size() - 1).getKey();
+
+    String firstKeyDescending = descendingMap.getKeyByRank(0);
+
+    assertThat(firstKeyDescending).isEqualTo(expectedKey);
+  }
+
+  @Test
+  public void testGetKeyByRank_descendingMapSecondElement() {
+    OrderStatisticMap<String, String> map = createMap(ELEMS);
+    OrderStatisticMap<String, String> descendingMap = map.descendingMap();
+    String expectedKey = ELEMS.get(ELEMS.size() - 2).getKey();
+
+    String sndKeyDescending = descendingMap.getKeyByRank(1);
+
+    assertThat(sndKeyDescending).isEqualTo(expectedKey);
+  }
+
+  @Test
+  public void testGetKeyByRank_descendingMapLastElement() {
+    OrderStatisticMap<String, String> map = createMap(ELEMS);
+    OrderStatisticMap<String, String> descendingMap = map.descendingMap();
+    String expectedKey = ELEMS.get(0).getKey();
+
+    String lastKeyDescending = descendingMap.getKeyByRank(descendingMap.size() - 1);
+
+    assertThat(lastKeyDescending).isEqualTo(expectedKey);
   }
 
   @Test
@@ -332,39 +490,207 @@ public abstract class OrderStatisticMapTestSuite {
 
     map.removeByRank(2);
 
-    Assert.assertFalse(containsEntry(map, ELEMS.get(2)));
-    Assert.assertTrue(containsEntry(map, ELEMS.get(0)));
-    Assert.assertTrue(containsEntry(map, ELEMS.get(1)));
-    Assert.assertTrue(containsEntry(map, ELEMS.get(3)));
+    assertThat(map).doesNotContainEntry(ELEMS.get(2).getKey(), ELEMS.get(2).getValue());
+    assertThat(map).containsEntry(ELEMS.get(0).getKey(), ELEMS.get(0).getValue());
+    assertThat(map).containsEntry(ELEMS.get(1).getKey(), ELEMS.get(1).getValue());
+    assertThat(map).containsEntry(ELEMS.get(3).getKey(), ELEMS.get(3).getValue());
 
     map.removeByRank(0);
 
-    Assert.assertFalse(containsEntry(map, ELEMS.get(0)));
-    Assert.assertTrue(containsEntry(map, ELEMS.get(1)));
-    Assert.assertTrue(containsEntry(map, ELEMS.get(3)));
+    assertThat(map).doesNotContainEntry(ELEMS.get(0).getKey(), ELEMS.get(0).getValue());
+    assertThat(map).containsEntry(ELEMS.get(1).getKey(), ELEMS.get(1).getValue());
+    assertThat(map).containsEntry(ELEMS.get(3).getKey(), ELEMS.get(3).getValue());
 
     map.removeByRank(map.size() - 1);
-    Assert.assertFalse(containsEntry(map, ELEMS.get(3)));
-    Assert.assertTrue(containsEntry(map, ELEMS.get(1)));
+    assertThat(map).doesNotContainEntry(ELEMS.get(3).getKey(), ELEMS.get(3).getValue());
+    assertThat(map).containsEntry(ELEMS.get(1).getKey(), ELEMS.get(1).getValue());
 
     map.removeByRank(0);
-    Assert.assertTrue(map.isEmpty());
+    assertThat(map).isEmpty();
   }
 
-  @Test(expected = IndexOutOfBoundsException.class)
+  @Test
   public void testRemoveByRank_invalid() {
     OrderStatisticMap<String, String> map = createMap(ELEMS);
+    OrderStatisticMap<String, String> emptyMap = createMap();
 
     try {
       map.removeByRank(-1);
-    } catch (IndexOutOfBoundsException e1) {
+      fail();
+    } catch (IndexOutOfBoundsException expected) {
       try {
         map.removeByRank(map.size());
-
-      } catch (IndexOutOfBoundsException e2) {
-        OrderStatisticMap<String, String> emptyMap = createMap();
-        emptyMap.removeByRank(0);
+        fail();
+      } catch (IndexOutOfBoundsException expected2) {
+        try {
+          emptyMap.removeByRank(0);
+          fail();
+        } catch (IndexOutOfBoundsException expected3) {
+          // expected outcome
+        }
       }
     }
+  }
+
+  @Test
+  public void testRemoveByRank_submapFirst() {
+    OrderStatisticMap<String, String> map = createMap(ELEMS);
+    Entry<String, String> submapStart = ELEMS.get(1);
+    String submapStartKey = submapStart.getKey();
+    String submapEnd = ELEMS.get(2).getKey();
+    OrderStatisticMap<String, String> subMap =
+        map.subMap(submapStartKey, /* fromInclusive= */ true, submapEnd, /* toInclusive= */ true);
+
+    String firstSubmapKey = subMap.removeByRank(0);
+
+    assertThat(firstSubmapKey).isEqualTo(submapStartKey);
+    assertThat(subMap).doesNotContainEntry(submapStart.getKey(), submapStart.getValue());
+    assertThat(map).doesNotContainEntry(submapStart.getKey(), submapStart.getValue());
+  }
+
+  @Test
+  public void testRemoveByRank_submapLast() {
+    OrderStatisticMap<String, String> map = createMap(ELEMS);
+    Entry<String, String> submapStart = ELEMS.get(1);
+    String submapStartKey = submapStart.getKey();
+    Entry<String, String> submapEnd = ELEMS.get(2);
+    String submapEndKey = submapEnd.getKey();
+    OrderStatisticMap<String, String> subMap =
+        map.subMap(
+            submapStartKey, /* fromInclusive= */ true, submapEndKey, /* toInclusive= */ true);
+
+    String lastSubmapKey = subMap.removeByRank(subMap.size() - 1);
+
+    assertThat(lastSubmapKey).isEqualTo(submapEndKey);
+    assertThat(subMap).doesNotContainEntry(submapEnd.getKey(), submapEnd.getValue());
+    assertThat(map).doesNotContainEntry(submapEnd.getKey(), submapEnd.getValue());
+  }
+
+  @Test
+  public void testRemoveByRank_descendingMapFirstElement() {
+    OrderStatisticMap<String, String> map = createMap(ELEMS);
+    OrderStatisticMap<String, String> descendingMap = map.descendingMap();
+    Entry<String, String> expectedRemove = ELEMS.get(ELEMS.size() - 1);
+    String expectedRemoveKey = expectedRemove.getKey();
+
+    String firstKeyDescending = descendingMap.removeByRank(0);
+
+    assertThat(firstKeyDescending).isEqualTo(expectedRemoveKey);
+    assertThat(descendingMap)
+        .doesNotContainEntry(expectedRemove.getKey(), expectedRemove.getValue());
+    assertThat(map).doesNotContainEntry(expectedRemove.getKey(), expectedRemove.getValue());
+  }
+
+  @Test
+  public void testRemoveByRank_descendingMapLastElement() {
+    OrderStatisticMap<String, String> map = createMap(ELEMS);
+    OrderStatisticMap<String, String> descendingMap = map.descendingMap();
+    Entry<String, String> expectedRemove = ELEMS.get(0);
+    String expectedRemoveKey = expectedRemove.getKey();
+
+    String lastKeyDescending = descendingMap.removeByRank(descendingMap.size() - 1);
+
+    assertThat(lastKeyDescending).isEqualTo(expectedRemoveKey);
+    assertThat(descendingMap)
+        .doesNotContainEntry(expectedRemove.getKey(), expectedRemove.getValue());
+    assertThat(map).doesNotContainEntry(expectedRemove.getKey(), expectedRemove.getValue());
+  }
+
+  private static <K, V> void assertRankOf(K pKey, int pExpectedRank, OrderStatisticMap<K, V> pMap) {
+    int actualRank = pMap.rankOf(pKey);
+
+    assertThat(actualRank).isEqualTo(pExpectedRank);
+  }
+
+  @Test
+  public void testRankOf_firstElement() {
+    OrderStatisticMap<String, String> map = createMap(ELEMS);
+
+    assertRankOf(ELEMS.get(0).getKey(), 0, map);
+  }
+
+  @Test
+  public void testRankOf_secondElement() {
+    OrderStatisticMap<String, String> map = createMap(ELEMS);
+
+    assertRankOf(ELEMS.get(1).getKey(), 1, map);
+  }
+
+  @Test
+  public void testRankOf_lastElement() {
+    OrderStatisticMap<String, String> map = createMap(ELEMS);
+    String key = ELEMS.get(ELEMS.size() - 1).getKey();
+    int expectedRank = ELEMS.size() - 1;
+
+    assertRankOf(key, expectedRank, map);
+  }
+
+  @Test
+  public void testRankOf_descendingMapFirstElement() {
+    OrderStatisticMap<String, String> descendingMap = createMap(ELEMS).descendingMap();
+    String key = ELEMS.get(ELEMS.size() - 1).getKey();
+    int expectedRank = 0;
+
+    assertRankOf(key, expectedRank, descendingMap);
+  }
+
+  @Test
+  public void testRankOf_descendingMapSecondElement() {
+    OrderStatisticMap<String, String> descendingMap = createMap(ELEMS).descendingMap();
+    String key = ELEMS.get(ELEMS.size() - 2).getKey();
+    int expectedRank = 1;
+
+    assertRankOf(key, expectedRank, descendingMap);
+  }
+
+  @Test
+  public void testRankOf_descendingMapLastElement() {
+    OrderStatisticMap<String, String> descendingMap = createMap(ELEMS).descendingMap();
+    String key = ELEMS.get(0).getKey();
+    int expectedRank = ELEMS.size() - 1;
+
+    assertRankOf(key, expectedRank, descendingMap);
+  }
+
+  @Test
+  public void testRankOf_subMapFirstElement() {
+    String firstSubmapKey = ELEMS.get(1).getKey();
+    String lastSubmapKey = ELEMS.get(3).getKey();
+    OrderStatisticMap<String, String> subMap =
+        createMap(ELEMS)
+            .subMap(
+                firstSubmapKey, /* fromInclusive= */ true, lastSubmapKey, /* toInclusive= */ true);
+    String key = firstSubmapKey;
+    int expectedRank = 0;
+
+    assertRankOf(key, expectedRank, subMap);
+  }
+
+  @Test
+  public void testRankOf_subMapLastElement() {
+    String firstSubmapKey = ELEMS.get(1).getKey();
+    String lastSubmapKey = ELEMS.get(3).getKey();
+    OrderStatisticMap<String, String> subMap =
+        createMap(ELEMS)
+            .subMap(
+                firstSubmapKey, /* fromInclusive= */ true, lastSubmapKey, /* toInclusive= */ true);
+    String key = lastSubmapKey;
+    int expectedRank = subMap.size() - 1;
+
+    assertRankOf(key, expectedRank, subMap);
+  }
+
+  @Test
+  public void testRankOf_subMapSecondElement() {
+    String firstSubmapKey = ELEMS.get(1).getKey();
+    String lastSubmapKey = ELEMS.get(3).getKey();
+    OrderStatisticMap<String, String> subMap =
+        createMap(ELEMS)
+            .subMap(
+                firstSubmapKey, /* fromInclusive= */ true, lastSubmapKey, /* toInclusive= */ true);
+    String key = ELEMS.get(2).getKey();
+    int expectedRank = 1;
+
+    assertRankOf(key, expectedRank, subMap);
   }
 }

--- a/src/org/sosy_lab/common/collect/OrderStatisticMapTestSuite.java
+++ b/src/org/sosy_lab/common/collect/OrderStatisticMapTestSuite.java
@@ -1,0 +1,360 @@
+/*
+ *  SoSy-Lab Common is a library of useful utilities.
+ *  This file is part of SoSy-Lab Common.
+ *
+ *  Copyright (C) 2007-2017  Dirk Beyer
+ *  All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.sosy_lab.common.collect;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import com.google.common.collect.testing.TestStringSortedMapGenerator;
+import com.google.common.testing.SerializableTester;
+import com.google.errorprone.annotations.Var;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.NavigableMap;
+import org.junit.Assert;
+import org.junit.Test;
+
+public abstract class OrderStatisticMapTestSuite {
+
+  @SuppressWarnings("unchecked")
+  private static final ImmutableList<Entry<String, String>> ELEMS =
+      ImmutableList.<Entry<String, String>>builder()
+          .add(Maps.immutableEntry("aaa", "Vzza"))
+          .add(Maps.immutableEntry("hha", "Vppa"))
+          .add(Maps.immutableEntry("ppa", "Vhha"))
+          .add(Maps.immutableEntry("zza", "Vaaa"))
+          .build();
+
+  @SuppressWarnings("unchecked")
+  private static final ImmutableList<Entry<String, String>> ELEMS_ABOVE =
+      ImmutableList.<Entry<String, String>>builder()
+          .add(Maps.immutableEntry("aab", "Vzzb"))
+          .add(Maps.immutableEntry("hhb", "Vppb"))
+          .add(Maps.immutableEntry("ppb", "Vhhb"))
+          .add(Maps.immutableEntry("zzb", "Vaab"))
+          .build();
+
+  @SuppressWarnings("unchecked")
+  private static final ImmutableList<Entry<String, String>> ELEMS_BELOW =
+      ImmutableList.<Entry<String, String>>builder()
+          .add(Maps.immutableEntry("aa", "Vzz"))
+          .add(Maps.immutableEntry("hh", "Vpp"))
+          .add(Maps.immutableEntry("pp", "Vhh"))
+          .add(Maps.immutableEntry("zz", "Vaa"))
+          .build();
+
+  public abstract static class OrderStatisticMapFactory extends TestStringSortedMapGenerator {
+
+    @Override
+    protected abstract OrderStatisticMap<String, String> create(Entry<String, String>[] pEntries);
+
+    protected abstract OrderStatisticMap<String, String> create(
+        List<Entry<String, String>> pEntries);
+  }
+
+  private OrderStatisticMapFactory factory;
+
+  public OrderStatisticMapTestSuite(OrderStatisticMapFactory pFactory) {
+    factory = pFactory;
+  }
+
+  @SuppressWarnings("unchecked")
+  private OrderStatisticMap<String, String> createMap() {
+    return factory.create(Collections.emptyList());
+  }
+
+  @SuppressWarnings("unchecked")
+  private OrderStatisticMap<String, String> createMap(List<Entry<String, String>> pEntries) {
+    return factory.create(pEntries);
+  }
+
+  private static <K, V> boolean containsEntry(Map<K, V> pMap, Entry<K, V> pEntry) {
+    return pMap.containsKey(pEntry.getKey()) && pEntry.getValue().equals(pMap.get(pEntry.getKey()));
+  }
+
+  private static <K, V> void putEntry(Map<K, V> pMap, Entry<K, V> pEntry) {
+    pMap.put(pEntry.getKey(), pEntry.getValue());
+  }
+
+  private static <K, V> void removeEntry(Map<K, V> pMap, Entry<K, V> pEntry) {
+    Assert.assertEquals(pMap.get(pEntry.getKey()), pMap.remove(pEntry.getKey()));
+  }
+
+  @Test
+  public void testEquals() {
+    OrderStatisticMap<String, String> l1 = createMap();
+    @Var OrderStatisticMap<String, String> l2 = createMap();
+
+    // Check that the map sorts its elements
+    Assert.assertEquals(l1, l2);
+    for (int i = ELEMS.size() - 1; i >= 0; i--) {
+      l2.put(ELEMS.get(i).getKey(), ELEMS.get(i).getValue());
+    }
+    for (int i = 0; i < ELEMS.size(); i++) {
+      l1.put(ELEMS.get(i).getKey(), ELEMS.get(i).getValue());
+    }
+    Assert.assertEquals(l1, l2);
+
+    // Check the map property
+    l2 = createMap();
+    for (int i = ELEMS.size() - 1; i >= 0; i--) {
+      l2.put(ELEMS.get(i).getKey(), ELEMS.get(i).getValue());
+    }
+    for (int i = 0; i < ELEMS.size(); i++) {
+      l2.put(ELEMS.get(i).getKey(), ELEMS.get(i).getValue());
+    }
+    Assert.assertEquals(l1, l2);
+  }
+
+  @Test
+  public void testSerialize() {
+    OrderStatisticMap<String, String> l = createMap();
+    SerializableTester.reserializeAndAssert(l);
+
+    for (int i = 100000; i >= 0; i--) {
+      l.put(String.valueOf(i), String.valueOf(i));
+    }
+    SerializableTester.reserializeAndAssert(l);
+  }
+
+  @Test
+  public void testSubmapView_mutation() {
+    NavigableMap<String, String> map = createMap(ELEMS);
+    NavigableMap<String, String> subMap =
+        map.subMap(ELEMS.get(1).getKey(), true, ELEMS.get(2).getKey(), true);
+
+    Entry<String, String> toAdd = ELEMS_BELOW.get(2);
+
+    putEntry(subMap, toAdd);
+    Assert.assertTrue(containsEntry(subMap, toAdd));
+    Assert.assertTrue(containsEntry(map, toAdd));
+
+    removeEntry(subMap, toAdd);
+    Assert.assertFalse(map.containsKey(toAdd.getKey()));
+    Assert.assertFalse(subMap.containsKey(toAdd.getKey()));
+
+    putEntry(map, toAdd);
+    Assert.assertTrue(containsEntry(subMap, toAdd));
+
+    removeEntry(map, toAdd);
+    Assert.assertFalse(containsEntry(subMap, toAdd));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testSubmapView_outOfBounds_add() {
+    NavigableMap<String, String> map = createMap(ELEMS);
+    NavigableMap<String, String> subMap =
+        map.subMap(
+            ELEMS_ABOVE.get(0).getKey(), true,
+            ELEMS_ABOVE.get(2).getKey(), true);
+
+    try {
+      putEntry(subMap, ELEMS.get(0));
+    } catch (IllegalArgumentException e1) {
+      try {
+        putEntry(subMap, ELEMS.get(3));
+      } catch (IllegalArgumentException e2) {
+        // the first 3 elements are in the range of the sublist, but the last isn't
+        Map<String, String> toAdd =
+            ImmutableMap.<String, String>builder()
+                .put(ELEMS.get(1))
+                .put(ELEMS_BELOW.get(2))
+                .put(ELEMS.get(2))
+                .put(ELEMS_ABOVE.get(3))
+                .build();
+        subMap.putAll(toAdd);
+      }
+    }
+  }
+
+  @Test
+  public void testSubmapView_outOfBounds_remove() {
+    NavigableMap<String, String> map = createMap(ELEMS);
+    NavigableMap<String, String> subMap =
+        map.subMap(
+            ELEMS_ABOVE.get(1).getKey(), true,
+            ELEMS_ABOVE.get(2).getKey(), true);
+
+    removeEntry(subMap, ELEMS.get(1));
+    removeEntry(subMap, ELEMS.get(3));
+
+    Assert.assertTrue(containsEntry(map, ELEMS.get(1)));
+    Assert.assertTrue(containsEntry(map, ELEMS.get(3)));
+
+    Map<String, String> toRemove =
+        ImmutableMap.<String, String>builder()
+            .put(ELEMS_BELOW.get(2))
+            .put(ELEMS.get(2))
+            .put(ELEMS.get(1))
+            .build();
+    for (Entry<String, String> e : toRemove.entrySet()) {
+      removeEntry(subMap, e);
+    }
+
+    Assert.assertTrue(containsEntry(map, ELEMS.get(1)));
+    Assert.assertFalse(containsEntry(map, ELEMS_BELOW.get(2)));
+    Assert.assertFalse(containsEntry(map, ELEMS.get(2)));
+  }
+
+  @Test
+  public void testSubmapView_outOfBounds_contains() {
+    NavigableMap<String, String> map = createMap(ELEMS);
+    @Var
+    NavigableMap<String, String> subMap =
+        map.subMap(
+            ELEMS_ABOVE.get(1).getKey(), true,
+            ELEMS_ABOVE.get(2).getKey(), true);
+
+    Assert.assertFalse(containsEntry(subMap, ELEMS.get(1)));
+    Assert.assertFalse(containsEntry(subMap, ELEMS.get(3)));
+
+    subMap = map.subMap(ELEMS_ABOVE.get(1).getKey(), false, ELEMS_ABOVE.get(2).getKey(), false);
+
+    Assert.assertFalse(containsEntry(subMap, ELEMS_ABOVE.get(1)));
+    Assert.assertFalse(containsEntry(subMap, ELEMS_ABOVE.get(2)));
+
+    subMap = map.subMap(ELEMS_ABOVE.get(0).getKey(), true, ELEMS_ABOVE.get(2).getKey(), true);
+
+    Assert.assertTrue(containsEntry(subMap, ELEMS.get(1)));
+    Assert.assertTrue(containsEntry(subMap, ELEMS.get(2)));
+  }
+
+  @Test
+  public void testSubmapView_descending() {
+    OrderStatisticMap<String, String> map = createMap(ELEMS);
+    @Var
+    OrderStatisticMap<String, String> subMap =
+        map.subMap(
+                ELEMS.get(1).getKey(), /* fromInclusive= */ true,
+                ELEMS.get(2).getKey(), /* toInclusive= */ true)
+            .descendingMap();
+
+    Assert.assertEquals(ELEMS.get(2), subMap.firstEntry());
+    Assert.assertEquals(ELEMS.get(1), subMap.lastEntry());
+
+    subMap = subMap.descendingMap();
+    Assert.assertEquals(ELEMS.get(1), subMap.firstEntry());
+    Assert.assertEquals(ELEMS.get(2), subMap.lastEntry());
+  }
+
+  @Test
+  public void testSubmapView_submapOfSubmap() {
+    OrderStatisticMap<String, String> map = createMap(ELEMS);
+    NavigableMap<String, String> subMap =
+        map.subMap(
+            ELEMS.get(1).getKey(), /* fromInclusive= */ true,
+            ELEMS.get(3).getKey(), /* toInclusive= */ true);
+    @Var
+    NavigableMap<String, String> subSubMap =
+        subMap.subMap(
+            ELEMS.get(1).getKey(), /* fromInclusive= */ true,
+            ELEMS_BELOW.get(3).getKey(), /* toInclusive= */ true);
+
+    Assert.assertFalse(containsEntry(subSubMap, ELEMS.get(0)));
+    Assert.assertTrue(containsEntry(subSubMap, ELEMS.get(1)));
+    Assert.assertTrue(containsEntry(subSubMap, ELEMS.get(2)));
+    Assert.assertFalse(containsEntry(subSubMap, ELEMS.get(3)));
+
+    // make sure that the inclusive-flags are respected
+    subSubMap =
+        subMap.subMap(
+            ELEMS.get(1).getKey(), /* fromInclusive= */ true,
+            ELEMS.get(3).getKey(), /* toInclusive=*/ true);
+    Assert.assertTrue(containsEntry(subSubMap, ELEMS.get(1)));
+    Assert.assertTrue(containsEntry(subSubMap, ELEMS.get(2)));
+    Assert.assertTrue(containsEntry(subSubMap, ELEMS.get(3)));
+
+    subSubMap =
+        subSubMap.subMap(
+            ELEMS.get(1).getKey(), /* fromInclusive= */ false,
+            ELEMS.get(3).getKey(), /* toInclusive= */ false);
+    Assert.assertFalse(containsEntry(subSubMap, ELEMS.get(1)));
+    Assert.assertTrue(containsEntry(subSubMap, ELEMS.get(2)));
+    Assert.assertFalse(containsEntry(subSubMap, ELEMS.get(3)));
+  }
+
+  @Test
+  public void testGetByRank_valid() {
+    OrderStatisticMap<String, String> map = createMap(ELEMS);
+
+    for (int i = 0; i < ELEMS.size(); i++) {
+      Assert.assertEquals(ELEMS.get(i), map.getEntryByRank(i));
+    }
+  }
+
+  @Test(expected = IndexOutOfBoundsException.class)
+  public void testGetByRank_outOfBounds() {
+    OrderStatisticMap<String, String> map = createMap(ELEMS);
+
+    try {
+      Entry<?, ?> x = map.getEntryByRank(-1);
+      Assert.assertFalse(x != null);
+      Assert.fail("Expected " + IndexOutOfBoundsException.class.getSimpleName());
+    } catch (IndexOutOfBoundsException e) {
+      Entry<?, ?> x = map.getEntryByRank(ELEMS.size());
+      Assert.assertFalse(x != null);
+      Assert.fail("Expected " + IndexOutOfBoundsException.class.getSimpleName());
+    }
+  }
+
+  @Test
+  public void testRemoveByRank_valid() {
+    OrderStatisticMap<String, String> map = createMap(ELEMS);
+
+    map.removeByRank(2);
+
+    Assert.assertFalse(containsEntry(map, ELEMS.get(2)));
+    Assert.assertTrue(containsEntry(map, ELEMS.get(0)));
+    Assert.assertTrue(containsEntry(map, ELEMS.get(1)));
+    Assert.assertTrue(containsEntry(map, ELEMS.get(3)));
+
+    map.removeByRank(0);
+
+    Assert.assertFalse(containsEntry(map, ELEMS.get(0)));
+    Assert.assertTrue(containsEntry(map, ELEMS.get(1)));
+    Assert.assertTrue(containsEntry(map, ELEMS.get(3)));
+
+    map.removeByRank(map.size() - 1);
+    Assert.assertFalse(containsEntry(map, ELEMS.get(3)));
+    Assert.assertTrue(containsEntry(map, ELEMS.get(1)));
+
+    map.removeByRank(0);
+    Assert.assertTrue(map.isEmpty());
+  }
+
+  @Test(expected = IndexOutOfBoundsException.class)
+  public void testRemoveByRank_invalid() {
+    OrderStatisticMap<String, String> map = createMap(ELEMS);
+
+    try {
+      map.removeByRank(-1);
+    } catch (IndexOutOfBoundsException e1) {
+      try {
+        map.removeByRank(map.size());
+
+      } catch (IndexOutOfBoundsException e2) {
+        OrderStatisticMap<String, String> emptyMap = createMap();
+        emptyMap.removeByRank(0);
+      }
+    }
+  }
+}

--- a/src/org/sosy_lab/common/collect/OrderStatisticSet.java
+++ b/src/org/sosy_lab/common/collect/OrderStatisticSet.java
@@ -1,0 +1,142 @@
+/*
+ *  SoSy-Lab Common is a library of useful utilities.
+ *  This file is part of SoSy-Lab Common.
+ *
+ *  Copyright (C) 2007-2017  Dirk Beyer
+ *  All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.sosy_lab.common.collect;
+
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.NavigableSet;
+
+/**
+ * A {@link NavigableSet} that allows two additional operations: receiving (and deleting) an element
+ * by its <i>rank</i>, and getting the rank of an element.
+ *
+ * <p>Implementations should adhere to all contracts of the <code>NavigableSet</code> interface.
+ *
+ * <p>Implementing classes should provide two means for comparing elements:
+ *
+ * <ol>
+ *   <li>Using the natural ordering of the elements. In this case, all elements of the set have to
+ *       implement the {@link Comparable} interface.
+ *   <li>Using a {@link java.util.Comparator Comparator} to create an order over the elements of the
+ *       set.
+ * </ol>
+ *
+ * <p>In both cases, the used compare-method should be consistent with <code>equals</code>, i.e.,
+ * <code>compare(a, b) == 0  =&gt;  a.equals(b)</code>, so that the contract provided by {@link
+ * java.util.Set Set} is fulfilled. If the used compare-method is not consistent with <code>equals
+ * </code>, the Set contract is not fulfilled.
+ *
+ * @param <E> the type of elements maintained by this set
+ */
+public interface OrderStatisticSet<E> extends NavigableSet<E> {
+
+  /**
+   * Returns the element of this set with the given rank. The lowest element in the set has rank ==
+   * 0, the largest element in the set has rank == size - 1.
+   *
+   * @param pIndex the rank of the element to return
+   * @return the element of this set with the given rank
+   * @throws IndexOutOfBoundsException if the given rank is out of the range of this set (i.e.,
+   *     pRank &lt; 0 || pRank &gt;= size)
+   */
+  E getByRank(int pIndex);
+
+  /**
+   * Remove the element of this set with the given rank and return it.
+   *
+   * <p>The lowest element in the set has rank == 0, the largest element in the set has rank == size
+   * - 1.
+   *
+   * @param pIndex the rank of the element to remove
+   * @return the removed element
+   * @throws IndexOutOfBoundsException if the given rank is out of the range of this set (i.e.,
+   *     pRank &lt; 0 || pRank &gt;= size)
+   * @see #getByRank(int)
+   */
+  @CanIgnoreReturnValue
+  E removeByRank(int pIndex);
+
+  /**
+   * Return the rank of the given element in this set. Returns -1 if the element does not exist in
+   * the set.
+   *
+   * <p>The lowest element in the set has rank == 0, the largest element in the set has rank == size
+   * - 1.
+   *
+   * @param pObj the element to return the rank for
+   * @return the rank of the given element in the set, or -1 if the element is not in the set
+   * @throws NullPointerException if the given element is <code>null</code>
+   */
+  int rankOf(E pObj);
+
+  @Override
+  OrderStatisticSet<E> descendingSet();
+
+  @Override
+  OrderStatisticSet<E> subSet(
+      E pFromElement, boolean fromInclusive, E pToElement, boolean toInclusive);
+
+  @Override
+  OrderStatisticSet<E> headSet(E pToElement, boolean inclusive);
+
+  @Override
+  OrderStatisticSet<E> tailSet(E pFromElement, boolean inclusive);
+
+  @Override
+  OrderStatisticSet<E> subSet(E pFromElement, E pToElement);
+
+  @Override
+  OrderStatisticSet<E> headSet(E pToElement);
+
+  @Override
+  OrderStatisticSet<E> tailSet(E pFromElement);
+
+  /** Creates a new empty OrderStatisticSet using natural ordering. */
+  static <E> OrderStatisticSet<E> create() {
+    return NaiveOrderStatisticSet.createSet();
+  }
+
+  /** Creates a new empty OrderStatisticSet using the given comparator. */
+  static <E> OrderStatisticSet<E> create(Comparator<? super E> pComparator) {
+    return NaiveOrderStatisticSet.createSet(pComparator);
+  }
+
+  /**
+   * Creates a new OrderStatisticSet containing the same elements as the given collection, using
+   * natural ordering.
+   */
+  static <E> OrderStatisticSet<E> createWithNaturalOrder(Collection<E> pCollection) {
+    return NaiveOrderStatisticSet.createSetWithNaturalOrder(pCollection);
+  }
+
+  /**
+   * Creates a new OrderStatisticSet containing the same elements and using the same order as the
+   * given {@link NavigableSet}.
+   *
+   * @param pNavigableSet set to use elements and ordering of
+   * @param <E> type of the elements of the given and new set
+   * @return a new OrderStatisticSet containing the same elements and using the same order as the
+   *     given set
+   */
+  static <E> OrderStatisticSet<E> createWithSameOrder(NavigableSet<E> pNavigableSet) {
+    return NaiveOrderStatisticSet.createSetWithSameOrder(pNavigableSet);
+  }
+}

--- a/src/org/sosy_lab/common/collect/OrderStatisticSet.java
+++ b/src/org/sosy_lab/common/collect/OrderStatisticSet.java
@@ -23,6 +23,7 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.NavigableSet;
+import java.util.SortedSet;
 
 /**
  * A {@link NavigableSet} that allows two additional operations: receiving (and deleting) an element
@@ -136,15 +137,15 @@ public interface OrderStatisticSet<E> extends NavigableSet<E> {
 
   /**
    * Creates a new OrderStatisticSet containing the same elements and using the same order as the
-   * given {@link NavigableSet}. The returned map guarantees performance only in O(n) for the
+   * given {@link SortedSet}. The returned map guarantees performance only in O(n) for the
    * operations specific to the OrderStatisticSet interface.
    *
-   * @param pNavigableSet set to use elements and ordering of
+   * @param pSortedSet set to use elements and ordering of
    * @param <E> type of the elements of the given and new set
    * @return a new OrderStatisticSet containing the same elements and using the same order as the
    *     given set
    */
-  static <E> OrderStatisticSet<E> createWithSameOrder(NavigableSet<E> pNavigableSet) {
-    return NaiveOrderStatisticSet.createSetWithSameOrder(pNavigableSet);
+  static <E> OrderStatisticSet<E> createWithSameOrder(SortedSet<E> pSortedSet) {
+    return NaiveOrderStatisticSet.createSetWithSameOrder(pSortedSet);
   }
 }

--- a/src/org/sosy_lab/common/collect/OrderStatisticSet.java
+++ b/src/org/sosy_lab/common/collect/OrderStatisticSet.java
@@ -109,19 +109,26 @@ public interface OrderStatisticSet<E> extends NavigableSet<E> {
   @Override
   OrderStatisticSet<E> tailSet(E pFromElement);
 
-  /** Creates a new empty OrderStatisticSet using natural ordering. */
+  /**
+   * Creates a new empty OrderStatisticSet using natural ordering. The returned map guarantees
+   * performance only in O(n) for the operations specific to the OrderStatisticSet interface.
+   */
   static <E> OrderStatisticSet<E> create() {
     return NaiveOrderStatisticSet.createSet();
   }
 
-  /** Creates a new empty OrderStatisticSet using the given comparator. */
+  /**
+   * Creates a new empty OrderStatisticSet using the given comparator. The returned map guarantees
+   * performance only in O(n) for the operations specific to the OrderStatisticSet interface.
+   */
   static <E> OrderStatisticSet<E> create(Comparator<? super E> pComparator) {
     return NaiveOrderStatisticSet.createSet(pComparator);
   }
 
   /**
    * Creates a new OrderStatisticSet containing the same elements as the given collection, using
-   * natural ordering.
+   * natural ordering. The returned map guarantees performance only in O(n) for the operations
+   * specific to the OrderStatisticSet interface.
    */
   static <E> OrderStatisticSet<E> createWithNaturalOrder(Collection<E> pCollection) {
     return NaiveOrderStatisticSet.createSetWithNaturalOrder(pCollection);
@@ -129,7 +136,8 @@ public interface OrderStatisticSet<E> extends NavigableSet<E> {
 
   /**
    * Creates a new OrderStatisticSet containing the same elements and using the same order as the
-   * given {@link NavigableSet}.
+   * given {@link NavigableSet}. The returned map guarantees performance only in O(n) for the
+   * operations specific to the OrderStatisticSet interface.
    *
    * @param pNavigableSet set to use elements and ordering of
    * @param <E> type of the elements of the given and new set

--- a/src/org/sosy_lab/common/collect/OrderStatisticSet.java
+++ b/src/org/sosy_lab/common/collect/OrderStatisticSet.java
@@ -20,7 +20,6 @@
 package org.sosy_lab.common.collect;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
-import java.util.Collection;
 import java.util.Comparator;
 import java.util.NavigableSet;
 import java.util.SortedSet;
@@ -127,11 +126,11 @@ public interface OrderStatisticSet<E> extends NavigableSet<E> {
   }
 
   /**
-   * Creates a new OrderStatisticSet containing the same elements as the given collection, using
+   * Creates a new OrderStatisticSet containing the same elements as the given Iterable, using
    * natural ordering. The returned map guarantees performance only in O(n) for the operations
    * specific to the OrderStatisticSet interface.
    */
-  static <E> OrderStatisticSet<E> createWithNaturalOrder(Collection<E> pCollection) {
+  static <E> OrderStatisticSet<E> createWithNaturalOrder(Iterable<E> pCollection) {
     return NaiveOrderStatisticSet.createSetWithNaturalOrder(pCollection);
   }
 

--- a/src/org/sosy_lab/common/collect/OrderStatisticSet.java
+++ b/src/org/sosy_lab/common/collect/OrderStatisticSet.java
@@ -52,6 +52,12 @@ public interface OrderStatisticSet<E> extends NavigableSet<E> {
    * Returns the element of this set with the given rank. The lowest element in the set has rank ==
    * 0, the largest element in the set has rank == size - 1.
    *
+   * <p>If this OrderStatisticSet is a view on some backing OrderStatisticSet (as created, e.g., by
+   * {@link #descendingSet()} or {@link #headSet(Object)}), the returned rank is in relation to the
+   * elements in the view, not in relation to the elements in the backing set. Thus, one can always
+   * expect that element of rank 0 is the first element in this set, and element of rank <code>
+   * {@link #size()} - 1</code> is the last.
+   *
    * @param pIndex the rank of the element to return
    * @return the element of this set with the given rank
    * @throws IndexOutOfBoundsException if the given rank is out of the range of this set (i.e.,
@@ -64,6 +70,12 @@ public interface OrderStatisticSet<E> extends NavigableSet<E> {
    *
    * <p>The lowest element in the set has rank == 0, the largest element in the set has rank == size
    * - 1.
+   *
+   * <p>If this OrderStatisticSet is a view on some backing OrderStatisticSet (as created, e.g., by
+   * {@link #descendingSet()} or {@link #headSet(Object)}), the returned rank is in relation to the
+   * elements in the view, not in relation to the elements in the backing set. Thus, one can always
+   * expect that element of rank 0 is the first element in this set, and element of rank <code>
+   * {@link #size()} - 1</code> is the last.
    *
    * @param pIndex the rank of the element to remove
    * @return the removed element
@@ -80,6 +92,12 @@ public interface OrderStatisticSet<E> extends NavigableSet<E> {
    *
    * <p>The lowest element in the set has rank == 0, the largest element in the set has rank == size
    * - 1.
+   *
+   * <p>If this OrderStatisticSet is a view on some backing OrderStatisticSet (as created, e.g., by
+   * {@link #descendingSet()} or {@link #headSet(Object)}), the returned rank is in relation to the
+   * elements in the view, not in relation to the elements in the backing set. Thus, one can always
+   * expect that element of rank 0 is the first element in this set, and element of rank <code>
+   * {@link #size()} - 1</code> is the last.
    *
    * @param pObj the element to return the rank for
    * @return the rank of the given element in the set, or -1 if the element is not in the set

--- a/src/org/sosy_lab/common/collect/OrderStatisticSetTestSuite.java
+++ b/src/org/sosy_lab/common/collect/OrderStatisticSetTestSuite.java
@@ -1,0 +1,282 @@
+/*
+ *  SoSy-Lab Common is a library of useful utilities.
+ *  This file is part of SoSy-Lab Common.
+ *
+ *  Copyright (C) 2007-2017  Dirk Beyer
+ *  All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.sosy_lab.common.collect;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.testing.TestStringSortedSetGenerator;
+import com.google.common.testing.SerializableTester;
+import com.google.errorprone.annotations.Var;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.NavigableSet;
+import org.junit.Assert;
+import org.junit.Test;
+
+public abstract class OrderStatisticSetTestSuite {
+
+  private static final String[] ELEMS = {"aaa", "hha", "ppa", "zza"};
+  private static final String[] ELEMS_ABOVE = {"aab", "hhb", "ppb", "zzb"};
+  private static final String[] ELEMS_BELOW = {"aa", "hh", "pp", "zz"};
+
+  public abstract static class OrderStatisticSetFactory extends TestStringSortedSetGenerator {
+
+    @Override
+    protected abstract OrderStatisticSet<String> create(String[] pStrings);
+  }
+
+  private OrderStatisticSetFactory factory;
+
+  public OrderStatisticSetTestSuite(OrderStatisticSetFactory pFactory) {
+    factory = pFactory;
+  }
+
+  private OrderStatisticSet<String> createSet() {
+    String[] elems = new String[0];
+    return factory.create(elems);
+  }
+
+  private OrderStatisticSet<String> createSet(String[] pElems) {
+    return factory.create(pElems);
+  }
+
+  @Test
+  public void testEquals() {
+    OrderStatisticSet<String> l1 = createSet();
+    @Var OrderStatisticSet<String> l2 = createSet();
+
+    Assert.assertEquals(l1, l2);
+
+    Collections.addAll(l1, "a", "b", "c", "d");
+    Assert.assertNotEquals(l1, l2);
+
+    Collections.addAll(l2, "d", "c", "a", "b");
+    Assert.assertEquals(l1, l2);
+
+    l2 = createSet();
+    Collections.addAll(l2, "d", "c", "a", "b", "a", "b", "a");
+    Assert.assertEquals(l1, l2);
+  }
+
+  @Test
+  public void testSerialize() {
+    OrderStatisticSet<String> l = createSet();
+    SerializableTester.reserializeAndAssert(l);
+
+    for (int i = 100000; i >= 0; i--) {
+      l.add(String.valueOf(i));
+    }
+    SerializableTester.reserializeAndAssert(l);
+  }
+
+  @Test
+  public void testSubsetView_mutation() {
+    NavigableSet<String> set = createSet(ELEMS);
+    NavigableSet<String> subSet = set.subSet(ELEMS[1], true, ELEMS[2], true);
+
+    String toAdd = ELEMS_BELOW[2];
+
+    subSet.add(toAdd);
+    Assert.assertTrue(subSet.contains(toAdd));
+    Assert.assertTrue(set.contains(toAdd));
+
+    subSet.remove(toAdd);
+    Assert.assertFalse(set.contains(toAdd));
+    Assert.assertFalse(subSet.contains(toAdd));
+
+    set.add(toAdd);
+    Assert.assertTrue(subSet.contains(toAdd));
+
+    set.remove(toAdd);
+    Assert.assertFalse(subSet.contains(toAdd));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testSubsetView_outOfBounds_add() {
+    NavigableSet<String> set = createSet(ELEMS);
+    NavigableSet<String> subSet = set.subSet(ELEMS_ABOVE[0], true, ELEMS_ABOVE[2], true);
+
+    try {
+      subSet.add(ELEMS[0]);
+    } catch (IllegalArgumentException e1) {
+      try {
+        subSet.add(ELEMS[3]);
+      } catch (IllegalArgumentException e2) {
+        // the first 3 elements are in the range of the sublist, but the last isn't
+        Collection<String> toAdd =
+            ImmutableList.of(ELEMS[1], ELEMS_BELOW[2], ELEMS[2], ELEMS_ABOVE[3]);
+        subSet.addAll(toAdd);
+      }
+    }
+  }
+
+  @Test
+  public void testSubsetView_outOfBounds_remove() {
+    NavigableSet<String> set = createSet(ELEMS);
+    NavigableSet<String> subSet = set.subSet(ELEMS_ABOVE[1], true, ELEMS_ABOVE[2], true);
+
+    subSet.remove(ELEMS[1]);
+    subSet.remove(ELEMS[3]);
+
+    Assert.assertTrue(set.contains(ELEMS[1]));
+    Assert.assertTrue(set.contains(ELEMS[3]));
+
+    Collection<String> toRemove = ImmutableList.of(ELEMS_BELOW[2], ELEMS[2], ELEMS[1]);
+    subSet.removeAll(toRemove);
+
+    Assert.assertTrue(set.contains(ELEMS[1]));
+    Assert.assertFalse(set.contains(ELEMS_BELOW[2]));
+    Assert.assertFalse(set.contains(ELEMS[2]));
+  }
+
+  @Test
+  public void testSubsetView_outOfBounds_contains() {
+    NavigableSet<String> set = createSet(ELEMS);
+    @Var NavigableSet<String> subSet = set.subSet(ELEMS_ABOVE[1], true, ELEMS_ABOVE[2], true);
+
+    Assert.assertFalse(subSet.contains(ELEMS[1]));
+    Assert.assertFalse(subSet.contains(ELEMS[3]));
+
+    subSet = set.subSet(ELEMS_ABOVE[1], false, ELEMS_ABOVE[2], false);
+
+    Assert.assertFalse(subSet.contains(ELEMS_ABOVE[1]));
+    Assert.assertFalse(subSet.contains(ELEMS_ABOVE[2]));
+
+    subSet = set.subSet(ELEMS_ABOVE[0], true, ELEMS_ABOVE[2], true);
+
+    Assert.assertTrue(subSet.contains(ELEMS[1]));
+    Assert.assertTrue(subSet.contains(ELEMS[2]));
+  }
+
+  @Test
+  public void testSubsetView_descending() {
+    OrderStatisticSet<String> set = createSet(ELEMS);
+    @Var
+    OrderStatisticSet<String> subSet =
+        set.subSet(
+                ELEMS[1], /* fromInclusive= */ true,
+                ELEMS[2], /* toInclusive= */ true)
+            .descendingSet();
+
+    Assert.assertEquals(ELEMS[2], subSet.first());
+    Assert.assertEquals(ELEMS[1], subSet.last());
+
+    subSet = subSet.descendingSet();
+    Assert.assertEquals(ELEMS[1], subSet.first());
+    Assert.assertEquals(ELEMS[2], subSet.last());
+  }
+
+  @Test
+  public void testSubsetView_subsetOfSubset() {
+    OrderStatisticSet<String> set = createSet(ELEMS);
+    NavigableSet<String> subSet =
+        set.subSet(ELEMS[1], /* fromInclusive= */ true, ELEMS[3], /*
+    toInclusive=
+    */ true);
+    @Var
+    NavigableSet<String> subSubSet =
+        subSet.subSet(
+            ELEMS[1], /* fromInclusive= */ true,
+            ELEMS_BELOW[3], /* toInclusive= */ true);
+
+    Assert.assertFalse(subSubSet.contains(ELEMS[0]));
+    Assert.assertTrue(subSubSet.contains(ELEMS[1]));
+    Assert.assertTrue(subSubSet.contains(ELEMS[2]));
+    Assert.assertFalse(subSubSet.contains(ELEMS[3]));
+
+    // make sure that the inclusive-flags are respected
+    subSubSet =
+        subSet.subSet(ELEMS[1], /* fromInclusive= */ true, ELEMS[3], /* toInclusive=*/ true);
+    Assert.assertTrue(subSubSet.contains(ELEMS[1]));
+    Assert.assertTrue(subSubSet.contains(ELEMS[2]));
+    Assert.assertTrue(subSubSet.contains(ELEMS[3]));
+
+    subSubSet =
+        subSubSet.subSet(ELEMS[1], /* fromInclusive= */ false, ELEMS[3], /* toInclusive= */ false);
+    Assert.assertFalse(subSubSet.contains(ELEMS[1]));
+    Assert.assertTrue(subSubSet.contains(ELEMS[2]));
+    Assert.assertFalse(subSubSet.contains(ELEMS[3]));
+  }
+
+  @Test
+  public void testGetByRank_valid() {
+    OrderStatisticSet<String> set = createSet(ELEMS);
+
+    for (int i = 0; i < ELEMS.length; i++) {
+      Assert.assertEquals(ELEMS[i], set.getByRank(i));
+    }
+  }
+
+  @Test(expected = IndexOutOfBoundsException.class)
+  public void testGetByRank_outOfBounds() {
+    OrderStatisticSet<String> set = createSet(ELEMS);
+
+    try {
+      String x = set.getByRank(-1);
+      Assert.assertFalse(x != null);
+      Assert.fail("Expected " + IndexOutOfBoundsException.class.getSimpleName());
+    } catch (IndexOutOfBoundsException e) {
+      String x = set.getByRank(ELEMS.length);
+      Assert.assertFalse(x != null);
+      Assert.fail("Expected " + IndexOutOfBoundsException.class.getSimpleName());
+    }
+  }
+
+  @Test
+  public void testRemoveByRank_valid() {
+    OrderStatisticSet<String> set = createSet(ELEMS);
+
+    set.removeByRank(2);
+
+    Assert.assertFalse(set.contains(ELEMS[2]));
+    Assert.assertTrue(set.contains(ELEMS[0]));
+    Assert.assertTrue(set.contains(ELEMS[1]));
+    Assert.assertTrue(set.contains(ELEMS[3]));
+
+    set.removeByRank(0);
+
+    Assert.assertFalse(set.contains(ELEMS[0]));
+    Assert.assertTrue(set.contains(ELEMS[1]));
+    Assert.assertTrue(set.contains(ELEMS[3]));
+
+    set.removeByRank(set.size() - 1);
+    Assert.assertFalse(set.contains(ELEMS[3]));
+    Assert.assertTrue(set.contains(ELEMS[1]));
+
+    set.removeByRank(0);
+    Assert.assertTrue(set.isEmpty());
+  }
+
+  @Test(expected = IndexOutOfBoundsException.class)
+  public void testRemoveByRank_invalid() {
+    OrderStatisticSet<String> set = createSet(ELEMS);
+
+    try {
+      set.removeByRank(-1);
+    } catch (IndexOutOfBoundsException e1) {
+      try {
+        set.removeByRank(set.size());
+
+      } catch (IndexOutOfBoundsException e2) {
+        OrderStatisticSet<String> emptySet = createSet();
+        emptySet.removeByRank(0);
+      }
+    }
+  }
+}

--- a/src/org/sosy_lab/common/collect/OrderStatisticSetTestSuite.java
+++ b/src/org/sosy_lab/common/collect/OrderStatisticSetTestSuite.java
@@ -19,6 +19,9 @@
  */
 package org.sosy_lab.common.collect;
 
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.testing.TestStringSortedSetGenerator;
 import com.google.common.testing.EqualsTester;
@@ -27,7 +30,6 @@ import com.google.errorprone.annotations.Var;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.NavigableSet;
-import org.junit.Assert;
 import org.junit.Test;
 
 public abstract class OrderStatisticSetTestSuite {
@@ -96,35 +98,41 @@ public abstract class OrderStatisticSetTestSuite {
     String toAdd = ELEMS_BELOW[2];
 
     subSet.add(toAdd);
-    Assert.assertTrue(subSet.contains(toAdd));
-    Assert.assertTrue(set.contains(toAdd));
+    assertThat(subSet).contains(toAdd);
+    assertThat(set).contains(toAdd);
 
     subSet.remove(toAdd);
-    Assert.assertFalse(set.contains(toAdd));
-    Assert.assertFalse(subSet.contains(toAdd));
+    assertThat(subSet).doesNotContain(toAdd);
+    assertThat(set).doesNotContain(toAdd);
 
     set.add(toAdd);
-    Assert.assertTrue(subSet.contains(toAdd));
+    assertThat(subSet).contains(toAdd);
 
     set.remove(toAdd);
-    Assert.assertFalse(subSet.contains(toAdd));
+    assertThat(subSet).doesNotContain(toAdd);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testSubsetView_outOfBounds_add() {
     NavigableSet<String> set = createSet(ELEMS);
     NavigableSet<String> subSet = set.subSet(ELEMS_ABOVE[0], true, ELEMS_ABOVE[2], true);
+    Collection<String> toAdd = ImmutableList.of(ELEMS[1], ELEMS_BELOW[2], ELEMS[2], ELEMS_ABOVE[3]);
 
     try {
       subSet.add(ELEMS[0]);
-    } catch (IllegalArgumentException e1) {
+      fail();
+    } catch (IllegalArgumentException expected) {
       try {
         subSet.add(ELEMS[3]);
-      } catch (IllegalArgumentException e2) {
-        // the first 3 elements are in the range of the sublist, but the last isn't
-        Collection<String> toAdd =
-            ImmutableList.of(ELEMS[1], ELEMS_BELOW[2], ELEMS[2], ELEMS_ABOVE[3]);
-        subSet.addAll(toAdd);
+        fail();
+      } catch (IllegalArgumentException expected2) {
+        try {
+          // the first 3 elements are in the range of the sublist, but the last isn't
+          subSet.addAll(toAdd);
+          fail();
+        } catch (IllegalArgumentException expected3) {
+          // expected outcome
+        }
       }
     }
   }
@@ -137,15 +145,15 @@ public abstract class OrderStatisticSetTestSuite {
     subSet.remove(ELEMS[1]);
     subSet.remove(ELEMS[3]);
 
-    Assert.assertTrue(set.contains(ELEMS[1]));
-    Assert.assertTrue(set.contains(ELEMS[3]));
+    assertThat(set).contains(ELEMS[1]);
+    assertThat(set).contains(ELEMS[3]);
 
     Collection<String> toRemove = ImmutableList.of(ELEMS_BELOW[2], ELEMS[2], ELEMS[1]);
     subSet.removeAll(toRemove);
 
-    Assert.assertTrue(set.contains(ELEMS[1]));
-    Assert.assertFalse(set.contains(ELEMS_BELOW[2]));
-    Assert.assertFalse(set.contains(ELEMS[2]));
+    assertThat(set).contains(ELEMS[1]);
+    assertThat(set).doesNotContain(ELEMS_BELOW[2]);
+    assertThat(set).doesNotContain(ELEMS[2]);
   }
 
   @Test
@@ -153,18 +161,18 @@ public abstract class OrderStatisticSetTestSuite {
     NavigableSet<String> set = createSet(ELEMS);
     @Var NavigableSet<String> subSet = set.subSet(ELEMS_ABOVE[1], true, ELEMS_ABOVE[2], true);
 
-    Assert.assertFalse(subSet.contains(ELEMS[1]));
-    Assert.assertFalse(subSet.contains(ELEMS[3]));
+    assertThat(subSet).doesNotContain(ELEMS[1]);
+    assertThat(subSet).doesNotContain(ELEMS[3]);
 
     subSet = set.subSet(ELEMS_ABOVE[1], false, ELEMS_ABOVE[2], false);
 
-    Assert.assertFalse(subSet.contains(ELEMS_ABOVE[1]));
-    Assert.assertFalse(subSet.contains(ELEMS_ABOVE[2]));
+    assertThat(subSet).doesNotContain(ELEMS_ABOVE[1]);
+    assertThat(subSet).doesNotContain(ELEMS_ABOVE[2]);
 
     subSet = set.subSet(ELEMS_ABOVE[0], true, ELEMS_ABOVE[2], true);
 
-    Assert.assertTrue(subSet.contains(ELEMS[1]));
-    Assert.assertTrue(subSet.contains(ELEMS[2]));
+    assertThat(subSet).contains(ELEMS[1]);
+    assertThat(subSet).contains(ELEMS[2]);
   }
 
   @Test
@@ -177,44 +185,42 @@ public abstract class OrderStatisticSetTestSuite {
                 ELEMS[2], /* toInclusive= */ true)
             .descendingSet();
 
-    Assert.assertEquals(ELEMS[2], subSet.first());
-    Assert.assertEquals(ELEMS[1], subSet.last());
+    assertThat(ELEMS[2]).isEqualTo(subSet.first());
+    assertThat(ELEMS[1]).isEqualTo(subSet.last());
 
     subSet = subSet.descendingSet();
-    Assert.assertEquals(ELEMS[1], subSet.first());
-    Assert.assertEquals(ELEMS[2], subSet.last());
+    assertThat(ELEMS[1]).isEqualTo(subSet.first());
+    assertThat(ELEMS[2]).isEqualTo(subSet.last());
   }
 
   @Test
   public void testSubsetView_subsetOfSubset() {
     OrderStatisticSet<String> set = createSet(ELEMS);
     NavigableSet<String> subSet =
-        set.subSet(ELEMS[1], /* fromInclusive= */ true, ELEMS[3], /*
-    toInclusive=
-    */ true);
+        set.subSet(ELEMS[1], /* fromInclusive= */ true, ELEMS[3], /* toInclusive=*/ true);
     @Var
     NavigableSet<String> subSubSet =
         subSet.subSet(
             ELEMS[1], /* fromInclusive= */ true,
             ELEMS_BELOW[3], /* toInclusive= */ true);
 
-    Assert.assertFalse(subSubSet.contains(ELEMS[0]));
-    Assert.assertTrue(subSubSet.contains(ELEMS[1]));
-    Assert.assertTrue(subSubSet.contains(ELEMS[2]));
-    Assert.assertFalse(subSubSet.contains(ELEMS[3]));
+    assertThat(subSubSet).doesNotContain(ELEMS[0]);
+    assertThat(subSubSet).contains(ELEMS[1]);
+    assertThat(subSubSet).contains(ELEMS[2]);
+    assertThat(subSubSet).doesNotContain(ELEMS[3]);
 
     // make sure that the inclusive-flags are respected
     subSubSet =
         subSet.subSet(ELEMS[1], /* fromInclusive= */ true, ELEMS[3], /* toInclusive=*/ true);
-    Assert.assertTrue(subSubSet.contains(ELEMS[1]));
-    Assert.assertTrue(subSubSet.contains(ELEMS[2]));
-    Assert.assertTrue(subSubSet.contains(ELEMS[3]));
+    assertThat(subSubSet).contains(ELEMS[1]);
+    assertThat(subSubSet).contains(ELEMS[2]);
+    assertThat(subSubSet).contains(ELEMS[3]);
 
     subSubSet =
         subSubSet.subSet(ELEMS[1], /* fromInclusive= */ false, ELEMS[3], /* toInclusive= */ false);
-    Assert.assertFalse(subSubSet.contains(ELEMS[1]));
-    Assert.assertTrue(subSubSet.contains(ELEMS[2]));
-    Assert.assertFalse(subSubSet.contains(ELEMS[3]));
+    assertThat(subSubSet).doesNotContain(ELEMS[1]);
+    assertThat(subSubSet).contains(ELEMS[2]);
+    assertThat(subSubSet).doesNotContain(ELEMS[3]);
   }
 
   @Test
@@ -222,23 +228,77 @@ public abstract class OrderStatisticSetTestSuite {
     OrderStatisticSet<String> set = createSet(ELEMS);
 
     for (int i = 0; i < ELEMS.length; i++) {
-      Assert.assertEquals(ELEMS[i], set.getByRank(i));
+      assertThat(ELEMS[i]).isEqualTo(set.getByRank(i));
     }
   }
 
-  @Test(expected = IndexOutOfBoundsException.class)
+  @Test
   public void testGetByRank_outOfBounds() {
     OrderStatisticSet<String> set = createSet(ELEMS);
 
     try {
-      String x = set.getByRank(-1);
-      Assert.assertFalse(x != null);
-      Assert.fail("Expected " + IndexOutOfBoundsException.class.getSimpleName());
-    } catch (IndexOutOfBoundsException e) {
-      String x = set.getByRank(ELEMS.length);
-      Assert.assertFalse(x != null);
-      Assert.fail("Expected " + IndexOutOfBoundsException.class.getSimpleName());
+      set.getByRank(-1);
+      fail("Expected " + IndexOutOfBoundsException.class.getSimpleName());
+    } catch (IndexOutOfBoundsException expected) {
+      try {
+        set.getByRank(ELEMS.length);
+        fail("Expected " + IndexOutOfBoundsException.class.getSimpleName());
+      } catch (IndexOutOfBoundsException expected2) {
+        // this is expected
+      }
     }
+  }
+
+  @Test
+  public void testGetByRank_subsetFirst() {
+    OrderStatisticSet<String> set = createSet(ELEMS);
+    OrderStatisticSet<String> subSet =
+        set.subSet(ELEMS[1], /* fromInclusive= */ true, ELEMS[2], /* toInclusive= */ true);
+
+    String firstSubSetElement = subSet.getByRank(0);
+
+    assertThat(firstSubSetElement).isEqualTo(ELEMS[1]);
+  }
+
+  @Test
+  public void testGetByRank_subsetLast() {
+    OrderStatisticSet<String> set = createSet(ELEMS);
+    OrderStatisticSet<String> subSet =
+        set.subSet(ELEMS[1], /* fromInclusive= */ true, ELEMS[2], /* toInclusive= */ true);
+
+    String lastSubSetElement = subSet.getByRank(subSet.size() - 1);
+
+    assertThat(lastSubSetElement).isEqualTo(ELEMS[2]);
+  }
+
+  @Test
+  public void testGetByRank_descendingSetFirstElement() {
+    OrderStatisticSet<String> set = createSet(ELEMS);
+    OrderStatisticSet<String> descendingSet = set.descendingSet();
+
+    String firstElementDescending = descendingSet.getByRank(0);
+
+    assertThat(firstElementDescending).isEqualTo(ELEMS[ELEMS.length - 1]);
+  }
+
+  @Test
+  public void testGetByRank_descendingSetSecondElement() {
+    OrderStatisticSet<String> set = createSet(ELEMS);
+    OrderStatisticSet<String> descendingSet = set.descendingSet();
+
+    String firstElementDescending = descendingSet.getByRank(1);
+
+    assertThat(firstElementDescending).isEqualTo(ELEMS[ELEMS.length - 2]);
+  }
+
+  @Test
+  public void testGetByRank_descendingSetLastElement() {
+    OrderStatisticSet<String> set = createSet(ELEMS);
+    OrderStatisticSet<String> descendingSet = set.descendingSet();
+
+    String lastElementDescending = descendingSet.getByRank(descendingSet.size() - 1);
+
+    assertThat(lastElementDescending).isEqualTo(ELEMS[0]);
   }
 
   @Test
@@ -247,39 +307,204 @@ public abstract class OrderStatisticSetTestSuite {
 
     set.removeByRank(2);
 
-    Assert.assertFalse(set.contains(ELEMS[2]));
-    Assert.assertTrue(set.contains(ELEMS[0]));
-    Assert.assertTrue(set.contains(ELEMS[1]));
-    Assert.assertTrue(set.contains(ELEMS[3]));
+    assertThat(set).doesNotContain(ELEMS[2]);
+    assertThat(set).contains(ELEMS[0]);
+    assertThat(set).contains(ELEMS[1]);
+    assertThat(set).contains(ELEMS[3]);
 
     set.removeByRank(0);
 
-    Assert.assertFalse(set.contains(ELEMS[0]));
-    Assert.assertTrue(set.contains(ELEMS[1]));
-    Assert.assertTrue(set.contains(ELEMS[3]));
+    assertThat(set).doesNotContain(ELEMS[0]);
+    assertThat(set).contains(ELEMS[1]);
+    assertThat(set).contains(ELEMS[3]);
 
     set.removeByRank(set.size() - 1);
-    Assert.assertFalse(set.contains(ELEMS[3]));
-    Assert.assertTrue(set.contains(ELEMS[1]));
+    assertThat(set).doesNotContain(ELEMS[3]);
+    assertThat(set).contains(ELEMS[1]);
 
     set.removeByRank(0);
-    Assert.assertTrue(set.isEmpty());
+    assertThat(set).isEmpty();
   }
 
-  @Test(expected = IndexOutOfBoundsException.class)
+  @Test
   public void testRemoveByRank_invalid() {
     OrderStatisticSet<String> set = createSet(ELEMS);
+    OrderStatisticSet<String> emptySet = createSet();
 
     try {
       set.removeByRank(-1);
-    } catch (IndexOutOfBoundsException e1) {
+      fail();
+    } catch (IndexOutOfBoundsException expected) {
       try {
         set.removeByRank(set.size());
-
-      } catch (IndexOutOfBoundsException e2) {
-        OrderStatisticSet<String> emptySet = createSet();
-        emptySet.removeByRank(0);
+        fail();
+      } catch (IndexOutOfBoundsException expected2) {
+        try {
+          emptySet.removeByRank(0);
+          fail();
+        } catch (IndexOutOfBoundsException expected3) {
+          // expected outcome
+        }
       }
     }
+  }
+
+  @Test
+  public void testRemoveByRank_subsetFirst() {
+    OrderStatisticSet<String> set = createSet(ELEMS);
+    OrderStatisticSet<String> subSet =
+        set.subSet(ELEMS[1], /* fromInclusive= */ true, ELEMS[2], /* toInclusive= */ true);
+
+    String firstSubSetElement = subSet.removeByRank(0);
+
+    assertThat(firstSubSetElement).isEqualTo(ELEMS[1]);
+    assertThat(subSet).doesNotContain(ELEMS[1]);
+    assertThat(set).doesNotContain(ELEMS[1]);
+  }
+
+  @Test
+  public void testRemoveByRank_subsetLast() {
+    OrderStatisticSet<String> set = createSet(ELEMS);
+    OrderStatisticSet<String> subSet =
+        set.subSet(ELEMS[1], /* fromInclusive= */ true, ELEMS[2], /* toInclusive= */ true);
+
+    String lastSubSetElement = subSet.removeByRank(subSet.size() - 1);
+
+    assertThat(lastSubSetElement).isEqualTo(ELEMS[2]);
+    assertThat(subSet).doesNotContain(ELEMS[2]);
+    assertThat(set).doesNotContain(ELEMS[2]);
+  }
+
+  @Test
+  public void testRemoveByRank_descendingSetFirstElement() {
+    OrderStatisticSet<String> set = createSet(ELEMS);
+    OrderStatisticSet<String> descendingSet = set.descendingSet();
+    String expectedRemove = ELEMS[ELEMS.length - 1];
+
+    String firstElementDescending = descendingSet.removeByRank(0);
+
+    assertThat(firstElementDescending).isEqualTo(expectedRemove);
+    assertThat(descendingSet).doesNotContain(expectedRemove);
+    assertThat(set).doesNotContain(expectedRemove);
+  }
+
+  @Test
+  public void testRemoveByRank_descendingSetLastElement() {
+    OrderStatisticSet<String> set = createSet(ELEMS);
+    OrderStatisticSet<String> descendingSet = set.descendingSet();
+    String expectedRemove = ELEMS[0];
+
+    String lastElementDescending = descendingSet.removeByRank(descendingSet.size() - 1);
+
+    assertThat(lastElementDescending).isEqualTo(expectedRemove);
+    assertThat(descendingSet).doesNotContain(expectedRemove);
+    assertThat(set).doesNotContain(expectedRemove);
+  }
+
+  private static <E> void assertRankOf(E pElement, int pExpectedRank, OrderStatisticSet<E> pSet) {
+    int actualRank = pSet.rankOf(pElement);
+
+    assertThat(actualRank).isEqualTo(pExpectedRank);
+  }
+
+  @Test
+  public void testRankOf_firstElement() {
+    OrderStatisticSet<String> set = createSet(ELEMS);
+
+    assertRankOf(ELEMS[0], 0, set);
+  }
+
+  @Test
+  public void testRankOf_secondElement() {
+    OrderStatisticSet<String> set = createSet(ELEMS);
+
+    assertRankOf(ELEMS[1], 1, set);
+  }
+
+  @Test
+  public void testRankOf_lastElement() {
+    OrderStatisticSet<String> set = createSet(ELEMS);
+    String element = ELEMS[ELEMS.length - 1];
+    int expectedRank = ELEMS.length - 1;
+
+    assertRankOf(element, expectedRank, set);
+  }
+
+  @Test
+  public void testRankOf_descendingSetFirstElement() {
+    OrderStatisticSet<String> descendingSet = createSet(ELEMS).descendingSet();
+    String element = ELEMS[ELEMS.length - 1];
+    int expectedRank = 0;
+
+    assertRankOf(element, expectedRank, descendingSet);
+  }
+
+  @Test
+  public void testRankOf_descendingSetSecondElement() {
+    OrderStatisticSet<String> descendingSet = createSet(ELEMS).descendingSet();
+    String element = ELEMS[ELEMS.length - 2];
+    int expectedRank = 1;
+
+    assertRankOf(element, expectedRank, descendingSet);
+  }
+
+  @Test
+  public void testRankOf_descendingSetLastElement() {
+    OrderStatisticSet<String> descendingSet = createSet(ELEMS).descendingSet();
+    String element = ELEMS[0];
+    int expectedRank = ELEMS.length - 1;
+
+    assertRankOf(element, expectedRank, descendingSet);
+  }
+
+  @Test
+  public void testRankOf_subSetFirstElement() {
+    String firstSubsetElement = ELEMS[1];
+    String lastSubsetElement = ELEMS[3];
+    OrderStatisticSet<String> subSet =
+        createSet(ELEMS)
+            .subSet(
+                firstSubsetElement,
+                /* fromInclusive= */ true,
+                lastSubsetElement,
+                /* toInclusive= */ true);
+    String element = firstSubsetElement;
+    int expectedRank = 0;
+
+    assertRankOf(element, expectedRank, subSet);
+  }
+
+  @Test
+  public void testRankOf_subSetLastElement() {
+    String firstSubsetElement = ELEMS[1];
+    String lastSubsetElement = ELEMS[3];
+    OrderStatisticSet<String> subSet =
+        createSet(ELEMS)
+            .subSet(
+                firstSubsetElement,
+                /* fromInclusive= */ true,
+                lastSubsetElement,
+                /* toInclusive= */ true);
+    String element = lastSubsetElement;
+    int expectedRank = subSet.size() - 1;
+
+    assertRankOf(element, expectedRank, subSet);
+  }
+
+  @Test
+  public void testRankOf_subSetSecondElement() {
+    String firstSubsetElement = ELEMS[1];
+    String lastSubsetElement = ELEMS[3];
+    OrderStatisticSet<String> subSet =
+        createSet(ELEMS)
+            .subSet(
+                firstSubsetElement,
+                /* fromInclusive= */ true,
+                lastSubsetElement,
+                /* toInclusive= */ true);
+    String element = ELEMS[2];
+    int expectedRank = 1;
+
+    assertRankOf(element, expectedRank, subSet);
   }
 }

--- a/src/org/sosy_lab/common/collect/OrderStatisticSetTestSuite.java
+++ b/src/org/sosy_lab/common/collect/OrderStatisticSetTestSuite.java
@@ -21,6 +21,7 @@ package org.sosy_lab.common.collect;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.testing.TestStringSortedSetGenerator;
+import com.google.common.testing.EqualsTester;
 import com.google.common.testing.SerializableTester;
 import com.google.errorprone.annotations.Var;
 import java.util.Collection;
@@ -58,20 +59,22 @@ public abstract class OrderStatisticSetTestSuite {
 
   @Test
   public void testEquals() {
-    OrderStatisticSet<String> l1 = createSet();
+    EqualsTester setEqualsTester = new EqualsTester();
+
+    @Var OrderStatisticSet<String> l1 = createSet();
     @Var OrderStatisticSet<String> l2 = createSet();
 
-    Assert.assertEquals(l1, l2);
+    setEqualsTester.addEqualityGroup(l1, l2);
 
-    Collections.addAll(l1, "a", "b", "c", "d");
-    Assert.assertNotEquals(l1, l2);
-
-    Collections.addAll(l2, "d", "c", "a", "b");
-    Assert.assertEquals(l1, l2);
-
+    l1 = createSet();
     l2 = createSet();
-    Collections.addAll(l2, "d", "c", "a", "b", "a", "b", "a");
-    Assert.assertEquals(l1, l2);
+    Collections.addAll(l1, "a", "b", "c", "d");
+    Collections.addAll(l2, "d", "c", "a", "b");
+
+    OrderStatisticSet<String> l3 = createSet();
+    Collections.addAll(l3, "d", "c", "a", "b", "a", "b", "a");
+    setEqualsTester.addEqualityGroup(l1, l2, l3);
+    setEqualsTester.testEquals();
   }
 
   @Test

--- a/src/org/sosy_lab/common/collect/OrderStatisticSetTestSuite.java
+++ b/src/org/sosy_lab/common/collect/OrderStatisticSetTestSuite.java
@@ -122,18 +122,22 @@ public abstract class OrderStatisticSetTestSuite {
       subSet.add(ELEMS[0]);
       fail();
     } catch (IllegalArgumentException expected) {
-      try {
-        subSet.add(ELEMS[3]);
-        fail();
-      } catch (IllegalArgumentException expected2) {
-        try {
-          // the first 3 elements are in the range of the sublist, but the last isn't
-          subSet.addAll(toAdd);
-          fail();
-        } catch (IllegalArgumentException expected3) {
-          // expected outcome
-        }
-      }
+      // expected outcome
+    }
+
+    try {
+      subSet.add(ELEMS[3]);
+      fail();
+    } catch (IllegalArgumentException expected) {
+      // expected outcome
+    }
+
+    try {
+      // the first 3 elements are in the range of the sublist, but the last isn't
+      subSet.addAll(toAdd);
+      fail();
+    } catch (IllegalArgumentException expected) {
+      // expected outcome
     }
   }
 
@@ -240,12 +244,13 @@ public abstract class OrderStatisticSetTestSuite {
       set.getByRank(-1);
       fail("Expected " + IndexOutOfBoundsException.class.getSimpleName());
     } catch (IndexOutOfBoundsException expected) {
-      try {
-        set.getByRank(ELEMS.length);
-        fail("Expected " + IndexOutOfBoundsException.class.getSimpleName());
-      } catch (IndexOutOfBoundsException expected2) {
-        // this is expected
-      }
+      // expected outcome
+    }
+    try {
+      set.getByRank(ELEMS.length);
+      fail("Expected " + IndexOutOfBoundsException.class.getSimpleName());
+    } catch (IndexOutOfBoundsException expected) {
+      // expected outcome
     }
   }
 
@@ -335,17 +340,19 @@ public abstract class OrderStatisticSetTestSuite {
       set.removeByRank(-1);
       fail();
     } catch (IndexOutOfBoundsException expected) {
-      try {
-        set.removeByRank(set.size());
-        fail();
-      } catch (IndexOutOfBoundsException expected2) {
-        try {
-          emptySet.removeByRank(0);
-          fail();
-        } catch (IndexOutOfBoundsException expected3) {
-          // expected outcome
-        }
-      }
+      // expected outcome
+    }
+    try {
+      set.removeByRank(set.size());
+      fail();
+    } catch (IndexOutOfBoundsException expected) {
+      // expected outcome
+    }
+    try {
+      emptySet.removeByRank(0);
+      fail();
+    } catch (IndexOutOfBoundsException expected) {
+      // expected outcome
     }
   }
 


### PR DESCRIPTION
Provides the `OrderStatisticMap` and `OrderStatisticSet` interface
with naive implementations.

The interfaces provide creator methods that return objects of the implementing `Naive*` classes.
The `OrderStatistic*TestSuite` classes aim to provide a small test suite for the current and future `OrderStatistic*` implementations.
