### PR TITLE
Timer provides #getMinTime() method

### DIFF
--- a/src/org/sosy_lab/common/time/Timer.java
+++ b/src/org/sosy_lab/common/time/Timer.java
@@ -192,8 +192,8 @@ public final class Timer {
   }
 
   /**
-   * Return the minimal time of all intervals. If the timer is running, the current interval is
-   * not considered. If the timer was never started, this method returns 0.
+   * Return the minimal time of all intervals. If the timer is running, the current interval is not
+   * considered. If the timer was never started, this method returns 0.
    */
   public TimeSpan getMinTime() {
     return export(minTime());

--- a/src/org/sosy_lab/common/time/Timer.java
+++ b/src/org/sosy_lab/common/time/Timer.java
@@ -29,8 +29,8 @@ import org.sosy_lab.common.time.Tickers.TickerWithUnit;
 
 /**
  * This class represents a timer like a stop watch. It can be started and stopped several times. It
- * measures return the sum, the average, the maximum and the number of those intervals. This class
- * is similar to {@link com.google.common.base.Stopwatch} but has more features.
+ * measures the sum, the average, the minimum, the maximum and the number of those intervals.
+ * This class is similar to {@link com.google.common.base.Stopwatch} but has more features.
  *
  * <p>This class is not thread-safe and may be used only from within a single thread.
  */
@@ -84,6 +84,11 @@ public final class Timer {
 
   /** The maximal time of all intervals. */
   private long maxTime = 0;
+
+  /**
+   * The minimal time of all intervals.
+   */
+  private long minTime = 0;
 
   /**
    * The number of intervals. This field should be accessed through {@link #getNumberOfIntervals()}
@@ -141,6 +146,7 @@ public final class Timer {
     lastIntervalLength = endTime - startTime;
     sumTime += lastIntervalLength;
     maxTime = Math.max(lastIntervalLength, maxTime);
+    minTime = Math.min(lastIntervalLength, minTime);
 
     // reset
     startTime = 0;
@@ -183,8 +189,20 @@ public final class Timer {
     return export(maxTime());
   }
 
+  /**
+   * Return the minimal time of all intervals. If timer is running, the current interval is also
+   * counted (up to the current time). If the timer was never started, this method returns 0.
+   */
+  public TimeSpan getMinTime() {
+    return export(minTime());
+  }
+
   long maxTime() {
     return Math.max(maxTime, currentInterval());
+  }
+
+  long minTime() {
+    return Math.min(minTime, currentInterval());
   }
 
   /**

--- a/src/org/sosy_lab/common/time/Timer.java
+++ b/src/org/sosy_lab/common/time/Timer.java
@@ -29,8 +29,8 @@ import org.sosy_lab.common.time.Tickers.TickerWithUnit;
 
 /**
  * This class represents a timer like a stop watch. It can be started and stopped several times. It
- * measures the sum, the average, the minimum, the maximum and the number of those intervals.
- * This class is similar to {@link com.google.common.base.Stopwatch} but has more features.
+ * measures the sum, the average, the minimum, the maximum and the number of those intervals. This
+ * class is similar to {@link com.google.common.base.Stopwatch} but has more features.
  *
  * <p>This class is not thread-safe and may be used only from within a single thread.
  */
@@ -86,9 +86,11 @@ public final class Timer {
   private long maxTime = 0;
 
   /**
-   * The minimal time of all intervals.
+   * The minimal time of all intervals. If no interval exists, this value is {@link Long#MAX_VALUE},
+   * but will be interpreted by method {@link #minTime()} as 0. Thus, method {@link #minTime()}
+   * should always be used to access this value in a meaningful way.
    */
-  private long minTime = 0;
+  private long minTime = Long.MAX_VALUE;
 
   /**
    * The number of intervals. This field should be accessed through {@link #getNumberOfIntervals()}
@@ -190,8 +192,8 @@ public final class Timer {
   }
 
   /**
-   * Return the minimal time of all intervals. If timer is running, the current interval is also
-   * counted (up to the current time). If the timer was never started, this method returns 0.
+   * Return the minimal time of all intervals. If the timer is running, the current interval is
+   * not considered. If the timer was never started, this method returns 0.
    */
   public TimeSpan getMinTime() {
     return export(minTime());
@@ -202,7 +204,12 @@ public final class Timer {
   }
 
   long minTime() {
-    return Math.min(minTime, currentInterval());
+    if (minTime == Long.MAX_VALUE) {
+      return 0;
+
+    } else {
+      return minTime;
+    }
   }
 
   /**

--- a/src/org/sosy_lab/common/time/TimerTest.java
+++ b/src/org/sosy_lab/common/time/TimerTest.java
@@ -32,6 +32,7 @@ public class TimerTest {
     assert_().that(timer.getSumTime()).isEqualTo(TimeSpan.empty());
     assert_().that(timer.getLengthOfLastInterval()).isEqualTo(TimeSpan.empty());
     assert_().that(timer.getMaxTime()).isEqualTo(TimeSpan.empty());
+    assert_().that(timer.getMinTime()).isEqualTo(TimeSpan.empty());
   }
 
   @Test


### PR DESCRIPTION
To get the minimum measured time across all intervals.

It would be interesting for me to also get the minimum time that some repeated computation took,
but was this left out on purpose?