### PR TITLE
Make tests pass on OpenBSD

### DIFF
--- a/src/org/sosy_lab/common/configuration/converters/FileTypeConverter.java
+++ b/src/org/sosy_lab/common/configuration/converters/FileTypeConverter.java
@@ -69,7 +69,7 @@ public final class FileTypeConverter implements TypeConverter {
           File.class, Path.class, PathTemplate.class, PathCounterTemplate.class);
 
   private static final String TEMP_DIR =
-      StandardSystemProperty.JAVA_IO_TMPDIR.value() + File.separator;
+      Paths.get(StandardSystemProperty.JAVA_IO_TMPDIR.value() + File.separator).toString();
 
   @Option(secure = true, name = "output.path", description = "directory to put all output files in")
   private String outputDirectory = "output/";

--- a/src/org/sosy_lab/common/configuration/converters/FileTypeConverterTest.java
+++ b/src/org/sosy_lab/common/configuration/converters/FileTypeConverterTest.java
@@ -128,6 +128,8 @@ public class FileTypeConverterTest {
 
     @Parameters(name = "{0} (safe={1}, safeInFile={2})")
     public static List<Object[]> testPaths() {
+      String tmpDir =
+          Paths.get(StandardSystemProperty.JAVA_IO_TMPDIR.value() + File.separator).toString();
       List<Object[]> tests =
           Lists.newArrayList(
               new Object[][] {
@@ -141,8 +143,8 @@ public class FileTypeConverterTest {
                 {"dir/../../file", false, true},
                 {"../../file", false, false},
                 {"dir/../../../file", false, false},
-                {StandardSystemProperty.JAVA_IO_TMPDIR.value() + "/file", true, true},
-                {StandardSystemProperty.JAVA_IO_TMPDIR.value() + "/../file", false, false},
+                {tmpDir + "/file", true, true},
+                {tmpDir + "/../file", false, false},
               });
       if (!isWindows()) {
         tests.add(new Object[] {"file::name", false, false});


### PR DESCRIPTION
JAVA_IO_TMPDIR.value() is "/tmp/" in OpenBSD. Adding another '/' to the end
would make the TEMP_DIR string in the FileTypeConverter class longer but
the path object will optimize the path.
Therefore "/tmp//.." is not "/tmp/.." (for a string comparison) and
"/tmp/../file" became "./file" in the FileTypeConverterTest class after a call
to CheckSafePath.