### PR TITLE
Modify copy mechanism of unused properties in configuration builder

### DIFF
--- a/src/org/sosy_lab/common/configuration/Configuration.java
+++ b/src/org/sosy_lab/common/configuration/Configuration.java
@@ -91,7 +91,7 @@ public final class Configuration {
 
   private static boolean secureMode = false;
 
-  private Configuration parent = null;
+  private final Configuration parent;
 
   /** Create a new Builder instance. */
   public static ConfigurationBuilder builder() {


### PR DESCRIPTION
Currently, when we have something like the following:

    Configuration newConfig = configBuilder.copyFrom(oldConfig).build();

the `newConfig` and the `oldConfig` share the same set of `unusedProperties`.

This has the downside that `newConfig` might add options that are not in the `oldConfig`. These are then nowhere marked as unused, despite the fact that this information is relevant for users.

This PR will address this by keeping the sets of `unusedProperties` separate and updating the set in `oldConfig` when the option is used in the `newConfig`.
The `unusedProperties` of `newConfig` are set to only contain properties that are only present in `newConfig`, not `oldConfig`. This has the advantage that unused properties are not reported redundantly.

I introduced a reference to the parent configuration inside the new configuration, this effectively leads to a tree-like structure where unused property tracking will work correctly across all levels.

The motivation behind this PR is to allow to check for unused options in subconfigs (c.f. [CPAchecker issue #545](https://gitlab.com/sosy-lab/software/cpachecker/issues/545)). It should be backwards compatible as far as the effect on `oldConfig` is concerned.

I have not yet added unit tests that test the new functionality, I will add them if there are no objections against this PR in general.
