### PR TITLE
Add MultiLineLogFormatter

### DIFF
--- a/src/org/sosy_lab/common/log/AbstractColoredLogFormatter.java
+++ b/src/org/sosy_lab/common/log/AbstractColoredLogFormatter.java
@@ -20,7 +20,7 @@ import java.util.logging.LogRecord;
  */
 abstract class AbstractColoredLogFormatter extends Formatter {
 
-  private boolean useColors;
+  private final boolean useColors;
 
   protected AbstractColoredLogFormatter(@Var boolean pUseColors) {
     if (pUseColors) {

--- a/src/org/sosy_lab/common/log/AbstractColoredLogFormatter.java
+++ b/src/org/sosy_lab/common/log/AbstractColoredLogFormatter.java
@@ -1,0 +1,77 @@
+// This file is part of SoSy-Lab Common,
+// a library of useful utilities:
+// https://github.com/sosy-lab/java-common-lib
+//
+// SPDX-FileCopyrightText: 2007-2020 Dirk Beyer <https://www.sosy-lab.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package org.sosy_lab.common.log;
+
+import com.google.common.base.MoreObjects;
+import com.google.errorprone.annotations.Var;
+import java.util.logging.Formatter;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+/**
+ * Abstract class for creating {@link Formatter}s that color {@link LogRecord}s with {@link
+ * Level#SEVERE} and {@link Level#WARNING} red.
+ */
+abstract class AbstractColoredLogFormatter extends Formatter {
+
+  private boolean useColors;
+
+  protected AbstractColoredLogFormatter(@Var boolean pUseColors) {
+    if (pUseColors) {
+      // Using colors is only good if stderr is connected to a terminal and not
+      // redirected into a file.
+      // AFAIK there is no way to determine this from Java, but at least there
+      // is a way to determine whether stdout is connected to a terminal.
+      // We assume that most users only redirect stderr if they also redirect
+      // stdout, so this should be ok.
+      if ((System.console() == null)
+          // Windows terminal does not support colors
+          || System.getProperty("os.name", "").startsWith("Windows")
+          // https://no-color.org/
+          || System.getenv("NO_COLOR") != null) {
+        pUseColors = false;
+      }
+    }
+    useColors = pUseColors;
+  }
+
+  @Override
+  public final String format(LogRecord lr) {
+    StringBuilder sb = new StringBuilder(200);
+
+    if (useColors) {
+      if (lr.getLevel().equals(Level.WARNING)) {
+        sb.append("\033[1m"); // bold normal color
+      } else if (lr.getLevel().equals(Level.SEVERE)) {
+        sb.append("\033[31;1m"); // bold red color
+      }
+    }
+    format(lr, sb);
+    if (useColors) {
+      sb.append("\033[m");
+    }
+    return sb.toString();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("useColors", useColors).toString();
+  }
+
+  /**
+   * Formats {@link LogRecord} using the provided {@link StringBuilder}.<br>
+   * This method corresponds to {@link Formatter#format(LogRecord)} in a template method pattern.
+   * The coloring behaviour is provided by superclass.
+   *
+   * @see Formatter#format(LogRecord)
+   * @param lr the {@link LogRecord} to format.
+   * @param sb the {@link StringBuilder} for {@link LogRecord} formatting.
+   */
+  protected abstract void format(LogRecord lr, StringBuilder sb);
+}

--- a/src/org/sosy_lab/common/log/BasicLogManager.java
+++ b/src/org/sosy_lab/common/log/BasicLogManager.java
@@ -231,7 +231,11 @@ public class BasicLogManager implements LogManager, AutoCloseable {
         Handler outfileHandler =
             new FileHandler(outputFile.toAbsolutePath().toString(), /*append=*/ false);
         setupHandler(
-            logger, outfileHandler, new FileLogFormatter(), fileLevel, options.getFileExclude());
+            logger,
+            outfileHandler,
+            TimestampedLogFormatter.withoutColors(),
+            fileLevel,
+            options.getFileExclude());
       } catch (IOException e) {
         // redirect log messages to console
         if (consoleLevel.intValue() > fileLevel.intValue()) {

--- a/src/org/sosy_lab/common/log/ConsoleLogFormatter.java
+++ b/src/org/sosy_lab/common/log/ConsoleLogFormatter.java
@@ -8,61 +8,31 @@
 
 package org.sosy_lab.common.log;
 
-import com.google.common.base.MoreObjects;
-import com.google.errorprone.annotations.Var;
 import java.util.Objects;
 import java.util.logging.Formatter;
-import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
 /** Class to handle formatting for console output. */
-public class ConsoleLogFormatter extends Formatter {
-
-  private final boolean useColors;
+public class ConsoleLogFormatter extends AbstractColoredLogFormatter {
 
   public ConsoleLogFormatter(LoggingOptions options) {
     this(options.useColors());
   }
 
-  private ConsoleLogFormatter(@Var boolean pUseColors) {
-
-    if (pUseColors) {
-      // Using colors is only good if stderr is connected to a terminal and not
-      // redirected into a file.
-      // AFAIK there is no way to determine this from Java, but at least there
-      // is a way to determine whether stdout is connected to a terminal.
-      // We assume that most users only redirect stderr if they also redirect
-      // stdout, so this should be ok.
-      if ((System.console() == null)
-          // Windows terminal does not support colors
-          || System.getProperty("os.name", "").startsWith("Windows")
-          // https://no-color.org/
-          || System.getenv("NO_COLOR") != null) {
-        pUseColors = false;
-      }
-    }
-    useColors = pUseColors;
+  private ConsoleLogFormatter(boolean useColors) {
+    super(useColors);
   }
 
   public static Formatter withoutColors() {
-    return new ConsoleLogFormatter(/*pUseColors=*/ false);
+    return new ConsoleLogFormatter(/*useColors=*/ false);
   }
 
   public static Formatter withColorsIfPossible() {
-    return new ConsoleLogFormatter(/*pUseColors=*/ true);
+    return new ConsoleLogFormatter(/*useColors=*/ true);
   }
 
   @Override
-  public String format(LogRecord lr) {
-    StringBuilder sb = new StringBuilder(200);
-
-    if (useColors) {
-      if (lr.getLevel().equals(Level.WARNING)) {
-        sb.append("\033[1m"); // bold normal color
-      } else if (lr.getLevel().equals(Level.SEVERE)) {
-        sb.append("\033[31;1m"); // bold red color
-      }
-    }
+  protected void format(LogRecord lr, StringBuilder sb) {
     sb.append(lr.getMessage()).append(" (");
     if (lr instanceof ExtendedLogRecord) {
       String component = ((ExtendedLogRecord) lr).getSourceComponentName();
@@ -77,16 +47,6 @@ public class ConsoleLogFormatter extends Formatter {
         .append(", ")
         .append(lr.getLevel().toString())
         .append(')');
-    if (useColors) {
-      sb.append("\033[m");
-    }
     sb.append("\n\n");
-
-    return sb.toString();
-  }
-
-  @Override
-  public String toString() {
-    return MoreObjects.toStringHelper(this).add("useColors", useColors).toString();
   }
 }

--- a/src/org/sosy_lab/common/log/FileLogFormatter.java
+++ b/src/org/sosy_lab/common/log/FileLogFormatter.java
@@ -8,46 +8,16 @@
 
 package org.sosy_lab.common.log;
 
-import com.google.common.base.MoreObjects;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
-import java.util.Locale;
-import java.util.Objects;
-import java.util.logging.Formatter;
-import java.util.logging.LogRecord;
+/** @deprecated use {@link TimestampedLogFormatter} instead. */
+@Deprecated
+public class FileLogFormatter extends TimestampedLogFormatter {
 
-/** Class to handle formatting for file output. */
-public class FileLogFormatter extends Formatter {
-
-  private static final DateTimeFormatter DATE_FORMAT =
-      DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss:SSS")
-          .withLocale(Locale.getDefault(Locale.Category.FORMAT))
-          .withZone(ZoneId.systemDefault());
-
-  @Override
-  public String format(LogRecord lr) {
-    StringBuilder sb = new StringBuilder();
-
-    DATE_FORMAT.formatTo(lr.getInstant(), sb);
-    sb.append('\t').append(lr.getLevel()).append('\t');
-
-    if (lr instanceof ExtendedLogRecord) {
-      String component = ((ExtendedLogRecord) lr).getSourceComponentName();
-      if (!component.isEmpty()) {
-        sb.append(component).append(':');
-      }
-    }
-    sb.append(Objects.requireNonNullElse(LogUtils.extractSimpleClassName(lr), "$Unknown$"))
-        .append('.')
-        .append(Objects.requireNonNullElse(lr.getSourceMethodName(), "$unknown$"))
-        .append('\t')
-        .append(lr.getMessage())
-        .append("\n\n");
-    return sb.toString();
+  /** @deprecated use {@link TimestampedLogFormatter#withoutColors()} */
+  @Deprecated
+  public FileLogFormatter() {
+    super(false);
   }
 
-  @Override
-  public String toString() {
-    return MoreObjects.toStringHelper(this).toString();
-  }
+
+
 }

--- a/src/org/sosy_lab/common/log/LogFormatterTest.java
+++ b/src/org/sosy_lab/common/log/LogFormatterTest.java
@@ -29,7 +29,8 @@ public class LogFormatterTest {
     return ImmutableList.of(
         ConsoleLogFormatter.withColorsIfPossible(),
         ConsoleLogFormatter.withoutColors(),
-        new FileLogFormatter());
+        TimestampedLogFormatter.withColorsIfPossible(),
+        TimestampedLogFormatter.withoutColors());
   }
 
   @Parameter(0)

--- a/src/org/sosy_lab/common/log/PackageSanityTest.java
+++ b/src/org/sosy_lab/common/log/PackageSanityTest.java
@@ -13,6 +13,7 @@ import com.google.common.testing.AbstractPackageSanityTests;
 import java.util.logging.Formatter;
 import java.util.logging.Handler;
 import java.util.logging.Level;
+import java.util.logging.LogRecord;
 import java.util.logging.SimpleFormatter;
 import org.sosy_lab.common.configuration.Configuration;
 import org.sosy_lab.common.configuration.InvalidConfigurationException;
@@ -24,6 +25,7 @@ public class PackageSanityTest extends AbstractPackageSanityTests {
     setDefault(Handler.class, new StringBuildingLogHandler());
     setDefault(Level.class, Level.ALL);
     setDefault(Formatter.class, new SimpleFormatter());
+    setDefault(LogRecord.class, new LogRecord(Level.ALL, "test"));
 
     setDefault(Configuration.class, Configuration.defaultConfiguration());
     try {

--- a/src/org/sosy_lab/common/log/TimestampedLogFormatter.java
+++ b/src/org/sosy_lab/common/log/TimestampedLogFormatter.java
@@ -18,8 +18,7 @@ import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
 /**
- * Class to handle timestamped log formatting:<br>
- *
+ * Log formatter that produces output containing a timestamp. Each log message will look like this:
  * <pre>
  * timestamp {@link Level} (component:class.method) message
  * </pre>

--- a/src/org/sosy_lab/common/log/TimestampedLogFormatter.java
+++ b/src/org/sosy_lab/common/log/TimestampedLogFormatter.java
@@ -8,7 +8,6 @@
 
 package org.sosy_lab.common.log;
 
-import com.google.common.base.MoreObjects;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
@@ -51,11 +50,6 @@ public class TimestampedLogFormatter extends AbstractColoredLogFormatter {
         .append('\t')
         .append(lr.getMessage())
         .append("\n\n");
-  }
-
-  @Override
-  public String toString() {
-    return MoreObjects.toStringHelper(this).toString();
   }
 
   public static Formatter withoutColors() {

--- a/src/org/sosy_lab/common/log/TimestampedLogFormatter.java
+++ b/src/org/sosy_lab/common/log/TimestampedLogFormatter.java
@@ -1,0 +1,69 @@
+// This file is part of SoSy-Lab Common,
+// a library of useful utilities:
+// https://github.com/sosy-lab/java-common-lib
+//
+// SPDX-FileCopyrightText: 2007-2020 Dirk Beyer <https://www.sosy-lab.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package org.sosy_lab.common.log;
+
+import com.google.common.base.MoreObjects;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.logging.Formatter;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+/**
+ * Class to handle timestamped log formatting:<br>
+ *
+ * <pre>
+ * timestamp {@link Level} (component:class.method) message
+ * </pre>
+ */
+public class TimestampedLogFormatter extends AbstractColoredLogFormatter {
+
+  private static final DateTimeFormatter DATE_FORMAT =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss:SSS")
+          .withLocale(Locale.getDefault(Locale.Category.FORMAT))
+          .withZone(ZoneId.systemDefault());
+
+  protected TimestampedLogFormatter(boolean useColors) {
+    super(useColors);
+  }
+
+  @Override
+  public void format(LogRecord lr, StringBuilder sb) {
+    DATE_FORMAT.formatTo(lr.getInstant(), sb);
+    sb.append('\t').append(lr.getLevel()).append('\t');
+
+    if (lr instanceof ExtendedLogRecord) {
+      String component = ((ExtendedLogRecord) lr).getSourceComponentName();
+      if (!component.isEmpty()) {
+        sb.append(component).append(':');
+      }
+    }
+    sb.append(Objects.requireNonNullElse(LogUtils.extractSimpleClassName(lr), "$Unknown$"))
+        .append('.')
+        .append(Objects.requireNonNullElse(lr.getSourceMethodName(), "$unknown$"))
+        .append('\t')
+        .append(lr.getMessage())
+        .append("\n\n");
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).toString();
+  }
+
+  public static Formatter withoutColors() {
+    return new TimestampedLogFormatter(/*useColors=*/ false);
+  }
+
+  public static Formatter withColorsIfPossible() {
+    return new TimestampedLogFormatter(/*useColors=*/ true);
+  }
+}


### PR DESCRIPTION
MultiLineLogFormatter that supports color mode when attached to console.
Prints timestamp, log level, first log message line, and component
description in this order as first line. Appends remaining log message
lines as additional lines.

Make the LogFormatter used in the VerifierCloud available for the witness-browser.