### PR TITLE
ProcessExecutor decrease loglevel on timeout and interruption

### DIFF
--- a/src/org/sosy_lab/common/ProcessExecutor.java
+++ b/src/org/sosy_lab/common/ProcessExecutor.java
@@ -352,12 +352,12 @@ public class ProcessExecutor<E extends Exception> {
       return exitCode;
 
     } catch (TimeoutException e) {
-      logger.logf(Level.WARNING, "Killing %s[%d] due to timeout", name, pid);
+      logger.logf(Level.FINEST, "Killing %s[%d] due to timeout", name, pid);
       processFuture.cancel(true);
       throw e;
 
     } catch (InterruptedException e) {
-      logger.logf(Level.WARNING, "Killing %s[%d] due to user interrupt", name, pid);
+      logger.logf(Level.FINEST, "Killing %s[%d] due to user interrupt", name, pid);
       processFuture.cancel(true);
       throw e;
 


### PR DESCRIPTION
Join re-throws a Interrupted/TimeoutException to the caller.
These cases may be considered by the caller as expected behaviour
and should not be logged as a WARNING.