### PR TITLE
Add support for detecting BSD systems in NativeLibraries

### DIFF
--- a/src/org/sosy_lab/common/NativeLibraries.java
+++ b/src/org/sosy_lab/common/NativeLibraries.java
@@ -213,7 +213,7 @@ public final class NativeLibraries {
    * NativeLibraries}.
    *
    * @param libraryName A library name as for {@link System#loadLibrary(String)}.
-   * @return Found path or {@code Optional.absent()}
+   * @return Found path or {@link Optional#empty()}
    */
   @Deprecated // will become private
   public static Optional<Path> findPathForLibrary(String libraryName) {

--- a/src/org/sosy_lab/common/NativeLibraries.java
+++ b/src/org/sosy_lab/common/NativeLibraries.java
@@ -35,7 +35,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  *       <p>Possible values for {@literal <arch>} include:
  *       <ul>
  *         <li>arm64
- *         <li>x86-64
+ *         <li>x86_64
  *         <li>x86
  *       </ul>
  *       <p>Possible values for {@literal <os>} include:

--- a/src/org/sosy_lab/common/NativeLibraries.java
+++ b/src/org/sosy_lab/common/NativeLibraries.java
@@ -219,13 +219,7 @@ public final class NativeLibraries {
   public static void loadLibrary(String name) {
     Optional<Path> path = findPathForLibrary(name);
     if (path.isPresent()) {
-      try {
-        System.load(path.orElseThrow().toAbsolutePath().toString());
-      } catch (UnsatisfiedLinkError e) {
-        // Revert to the system loader if we could not load the library that was found
-        System.loadLibrary(name);
-      }
-
+      System.load(path.orElseThrow().toAbsolutePath().toString());
     } else {
       System.loadLibrary(name);
     }

--- a/src/org/sosy_lab/common/NativeLibraries.java
+++ b/src/org/sosy_lab/common/NativeLibraries.java
@@ -29,8 +29,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  *
  * <ul>
  *   <li>the "native library path" as returned by {@link #getNativeLibraryPath()}, which is the
- *       directory {@literal ../native/<arch>-<os>/} relative to the JAR file of this library,
- *       where {@literal <arch>} stands for your processor architecture and {@literal <os>} for the
+ *       directory {@literal ../native/<arch>-<os>/} relative to the JAR file of this library, where
+ *       {@literal <arch>} stands for your processor architecture and {@literal <os>} for the
  *       operating system.
  *       <p>Possible values for {@literal <arch>} include:
  *       <ul>

--- a/src/org/sosy_lab/common/NativeLibraries.java
+++ b/src/org/sosy_lab/common/NativeLibraries.java
@@ -217,15 +217,26 @@ public final class NativeLibraries {
    */
   @Deprecated // will become private
   public static Optional<Path> findPathForLibrary(String libraryName) {
+    @Var Path p;
+    try {
+      // Try to get the native library path
+      p = getNativeLibraryPath();
+    } catch (UnsatisfiedLinkError e) {
+      // Return Optional.empty if operating system or architecture are unknown to us
+      return Optional.empty();
+    }
     String osLibName = System.mapLibraryName(libraryName);
-    @Var Path p = getNativeLibraryPath().resolve(osLibName).toAbsolutePath();
+    // Look for the library in the native library path
+    p = p.resolve(osLibName).toAbsolutePath();
     if (Files.exists(p)) {
       return Optional.of(p);
     }
+    // Look for the library next to the *.jar file
     p = Classes.getCodeLocation(NativeLibraries.class).resolveSibling(osLibName).toAbsolutePath();
     if (Files.exists(p)) {
       return Optional.of(p);
     }
+    // If nothing was found, return Optional.empty
     return Optional.empty();
   }
 }

--- a/src/org/sosy_lab/common/NativeLibraries.java
+++ b/src/org/sosy_lab/common/NativeLibraries.java
@@ -47,7 +47,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  *         <li>netbsd
  *         <li>openbsd
  *       </ul>
- *   <li>the same directory as the JAR file of this library. (Only on Linux, Windows and MacOS)
+ *   <li>the same directory as the JAR file of this library
  * </ul>
  *
  * <p>Standard usage is by calling the method {@link NativeLibraries#loadLibrary} with the library
@@ -239,12 +239,9 @@ public final class NativeLibraries {
     if (Files.exists(p)) {
       return Optional.of(p);
     }
-    var system = OS.guessOperatingSystem();
-    if (system == OS.LINUX || system == OS.WINDOWS || system == OS.MACOSX) {
-      p = Classes.getCodeLocation(NativeLibraries.class).resolveSibling(osLibName).toAbsolutePath();
-      if (Files.exists(p)) {
-        return Optional.of(p);
-      }
+    p = Classes.getCodeLocation(NativeLibraries.class).resolveSibling(osLibName).toAbsolutePath();
+    if (Files.exists(p)) {
+      return Optional.of(p);
     }
     return Optional.empty();
   }

--- a/src/org/sosy_lab/common/NativeLibraries.java
+++ b/src/org/sosy_lab/common/NativeLibraries.java
@@ -28,18 +28,26 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * <p>The searched directories are:
  *
  * <ul>
- *   <li>the same directory as the JAR file of this library
  *   <li>the "native library path" as returned by {@link #getNativeLibraryPath()}, which is the
- *       directory {@literal ../native/<arch>-<os>/} relative to the JAR file of this library, with
- *       {@literal <arch>-<os>} being one of the following values depending on your system:
+ *       directory {@literal ../native/<arch>-<os>/} relative to the JAR file of this library,
+ *       where {@literal <arch>} stands for your processor architecture and {@literal <os>} for the
+ *       operating system.
+ *       <p>Possible values for {@literal <arch>} include:
  *       <ul>
- *         <li>x86_64-linux
- *         <li>x86-linux
- *         <li>x86-windows
- *         <li>x86_64-windows
- *         <li>x86-macosx
- *         <li>x86_64-macosx
+ *         <li>arm64
+ *         <li>x86-64
+ *         <li>x86
  *       </ul>
+ *       <p>Possible values for {@literal <os>} include:
+ *       <ul>
+ *         <li>linux
+ *         <li>windows
+ *         <li>macosx
+ *         <li>freebsd
+ *         <li>netbsd
+ *         <li>openbsd
+ *       </ul>
+ *   <li>the same directory as the JAR file of this library
  * </ul>
  *
  * <p>Standard usage is by calling the method {@link NativeLibraries#loadLibrary} with the library
@@ -61,7 +69,10 @@ public final class NativeLibraries {
   public enum OS {
     LINUX,
     MACOSX,
-    WINDOWS;
+    WINDOWS,
+    FREEBSD,
+    NETBSD,
+    OPENBSD;
 
     @SuppressWarnings("MemberName")
     private static @Nullable OS currentOS = null;
@@ -84,6 +95,12 @@ public final class NativeLibraries {
         currentOS = WINDOWS;
       } else if (prop.startsWith("macosx")) {
         currentOS = MACOSX;
+      } else if (prop.startsWith("freebsd")) {
+        currentOS = FREEBSD;
+      } else if (prop.startsWith("netbsd")) {
+        currentOS = NETBSD;
+      } else if (prop.startsWith("openbsd")) {
+        currentOS = OPENBSD;
       } else {
         throw new UnsatisfiedLinkError(
             "Unknown value for os.name: '"
@@ -202,7 +219,13 @@ public final class NativeLibraries {
   public static void loadLibrary(String name) {
     Optional<Path> path = findPathForLibrary(name);
     if (path.isPresent()) {
-      System.load(path.orElseThrow().toAbsolutePath().toString());
+      try {
+        System.load(path.orElseThrow().toAbsolutePath().toString());
+      } catch (UnsatisfiedLinkError e) {
+        // Revert to the system loader if we could not load the library that was found
+        System.loadLibrary(name);
+      }
+
     } else {
       System.loadLibrary(name);
     }
@@ -217,26 +240,15 @@ public final class NativeLibraries {
    */
   @Deprecated // will become private
   public static Optional<Path> findPathForLibrary(String libraryName) {
-    @Var Path p;
-    try {
-      // Try to get the native library path
-      p = getNativeLibraryPath();
-    } catch (UnsatisfiedLinkError e) {
-      // Return Optional.empty if operating system or architecture are unknown to us
-      return Optional.empty();
-    }
     String osLibName = System.mapLibraryName(libraryName);
-    // Look for the library in the native library path
-    p = p.resolve(osLibName).toAbsolutePath();
+    @Var Path p = getNativeLibraryPath().resolve(osLibName).toAbsolutePath();
     if (Files.exists(p)) {
       return Optional.of(p);
     }
-    // Look for the library next to the *.jar file
     p = Classes.getCodeLocation(NativeLibraries.class).resolveSibling(osLibName).toAbsolutePath();
     if (Files.exists(p)) {
       return Optional.of(p);
     }
-    // If nothing was found, return Optional.empty
     return Optional.empty();
   }
 }

--- a/src/org/sosy_lab/common/NativeLibraries.java
+++ b/src/org/sosy_lab/common/NativeLibraries.java
@@ -47,7 +47,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  *         <li>netbsd
  *         <li>openbsd
  *       </ul>
- *   <li>the same directory as the JAR file of this library
+ *   <li>the same directory as the JAR file of this library. (Only on Linux, Windows and MacOS)
  * </ul>
  *
  * <p>Standard usage is by calling the method {@link NativeLibraries#loadLibrary} with the library
@@ -239,9 +239,12 @@ public final class NativeLibraries {
     if (Files.exists(p)) {
       return Optional.of(p);
     }
-    p = Classes.getCodeLocation(NativeLibraries.class).resolveSibling(osLibName).toAbsolutePath();
-    if (Files.exists(p)) {
-      return Optional.of(p);
+    var system = OS.guessOperatingSystem();
+    if (system == OS.LINUX || system == OS.WINDOWS || system == OS.MACOSX) {
+      p = Classes.getCodeLocation(NativeLibraries.class).resolveSibling(osLibName).toAbsolutePath();
+      if (Files.exists(p)) {
+        return Optional.of(p);
+      }
     }
     return Optional.empty();
   }


### PR DESCRIPTION
Hello,

this PR makes sure that the system load is tried if `NativeLibraries.loadLibrary()` fails because it can't recognize the operating system or the architecture of the system. Falling back to the system loader is the default behavior for `NativeLibraries.loadLibrary()`. However, the fallback will currently not work on unsupported systems, such as FreeBSD, as an exception is thrown instead

See https://github.com/sosy-lab/java-smt/issues/592 for the JavaSMT issue