### PR TITLE
Extend persistent path copying map with size tracking

### DIFF
--- a/src/org/sosy_lab/common/collect/PathCopyingPersistentTreeMap.java
+++ b/src/org/sosy_lab/common/collect/PathCopyingPersistentTreeMap.java
@@ -130,7 +130,7 @@ public final class PathCopyingPersistentTreeMap<
       return n != null && !n.isRed;
     }
 
-    private static int size(Node<?, ?> n) {
+    private static int size(@Nullable Node<?, ?> n) {
       return n == null ? 0 : n.subtreeSize;
     }
 

--- a/src/org/sosy_lab/common/collect/PathCopyingPersistentTreeMap.java
+++ b/src/org/sosy_lab/common/collect/PathCopyingPersistentTreeMap.java
@@ -94,6 +94,7 @@ public final class PathCopyingPersistentTreeMap<
     private final @Nullable Node<K, V> left;
     private final @Nullable Node<K, V> right;
     private final boolean isRed;
+    private final int subtreeSize;
 
     // Leaf node
     Node(K pKey, V pValue) {
@@ -101,6 +102,7 @@ public final class PathCopyingPersistentTreeMap<
       left = null;
       right = null;
       isRed = RED;
+      subtreeSize = 1;
     }
 
     // Any node
@@ -109,6 +111,7 @@ public final class PathCopyingPersistentTreeMap<
       left = pLeft;
       right = pRight;
       isRed = pRed;
+      subtreeSize = 1 + size(pLeft) + size(pRight);
     }
 
     boolean isLeaf() {
@@ -125,6 +128,10 @@ public final class PathCopyingPersistentTreeMap<
 
     static boolean isBlack(@Nullable Node<?, ?> n) {
       return n != null && !n.isRed;
+    }
+
+    private static int size(Node<?, ?> n) {
+      return n == null ? 0 : n.subtreeSize;
     }
 
     // Methods for creating new nodes based on current node.
@@ -850,7 +857,7 @@ public final class PathCopyingPersistentTreeMap<
   @Override
   public int size() {
     if (size <= 0) {
-      size = Node.countNodes(root);
+      size = Node.size(root);
     }
     return size;
   }

--- a/src/org/sosy_lab/common/collect/PathCopyingPersistentTreeMapTest.java
+++ b/src/org/sosy_lab/common/collect/PathCopyingPersistentTreeMapTest.java
@@ -522,9 +522,9 @@ public class PathCopyingPersistentTreeMapTest {
     versions.add(map);
     expectedVersionSizes.add(map.size());
 
-    for (String key : keyDeletionOrder) {
-      map = map.removeAndCopy(key);
-      oracle.remove(key);
+    for (String keyToDelete : keyDeletionOrder) {
+      map = map.removeAndCopy(keyToDelete);
+      oracle.remove(keyToDelete);
 
       versions.add(map);
       expectedVersionSizes.add(map.size());
@@ -537,7 +537,8 @@ public class PathCopyingPersistentTreeMapTest {
 
         @Var int count = 0;
 
-        for (Map.Entry<String, String> unused : map.entrySet()) {
+        for (String key : map.keySet()) {
+          assertThat(oracle.contains(key)).isTrue();
           count++;
         }
 

--- a/src/org/sosy_lab/common/collect/PathCopyingPersistentTreeMapTest.java
+++ b/src/org/sosy_lab/common/collect/PathCopyingPersistentTreeMapTest.java
@@ -452,70 +452,6 @@ public class PathCopyingPersistentTreeMapTest {
   }
 
   @Test
-  public void testSizeTracksMultipleInsertionsAcrossAllVersions() {
-    // Insert keys in non-ascending order and verify that size() reflects
-    // the number of entries for all versions after each insertion
-    PersistentSortedMap<String, String> map2 = map.putAndCopy("6", "A");
-    assertThat(map.size()).isEqualTo(0);
-    assertThat(map2.size()).isEqualTo(1);
-    PersistentSortedMap<String, String> map3 = map2.putAndCopy("3", "B");
-    assertThat(map.size()).isEqualTo(0);
-    assertThat(map2.size()).isEqualTo(1);
-    assertThat(map3.size()).isEqualTo(2);
-    PersistentSortedMap<String, String> map4 = map3.putAndCopy("9", "C");
-    assertThat(map.size()).isEqualTo(0);
-    assertThat(map2.size()).isEqualTo(1);
-    assertThat(map3.size()).isEqualTo(2);
-    assertThat(map4.size()).isEqualTo(3);
-    PersistentSortedMap<String, String> map5 = map4.putAndCopy("2", "D");
-    assertThat(map.size()).isEqualTo(0);
-    assertThat(map2.size()).isEqualTo(1);
-    assertThat(map3.size()).isEqualTo(2);
-    assertThat(map4.size()).isEqualTo(3);
-    assertThat(map5.size()).isEqualTo(4);
-    PersistentSortedMap<String, String> map6 = map5.putAndCopy("5", "E");
-    assertThat(map.size()).isEqualTo(0);
-    assertThat(map2.size()).isEqualTo(1);
-    assertThat(map3.size()).isEqualTo(2);
-    assertThat(map4.size()).isEqualTo(3);
-    assertThat(map5.size()).isEqualTo(4);
-    assertThat(map6.size()).isEqualTo(5);
-  }
-
-  @Test
-  public void testSizeTracksMultipleDeletionsAcrossAllVersions() {
-    // Insert keys in non-ascending order and verify that size() reflects
-    // the number of entries for all versions after each key deletion
-    map = map.putAndCopy("6", "A").putAndCopy("3", "B").putAndCopy("9", "C")
-    .putAndCopy("2", "D").putAndCopy("5", "E");
-    PersistentSortedMap<String, String> map2 = map.removeAndCopy("6");
-    assertThat(map.size()).isEqualTo(5);
-    assertThat(map2.size()).isEqualTo(4);
-    PersistentSortedMap<String, String> map3 = map2.removeAndCopy("3");
-    assertThat(map.size()).isEqualTo(5);
-    assertThat(map2.size()).isEqualTo(4);
-    assertThat(map3.size()).isEqualTo(3);
-    PersistentSortedMap<String, String> map4 = map3.removeAndCopy("9");
-    assertThat(map.size()).isEqualTo(5);
-    assertThat(map2.size()).isEqualTo(4);
-    assertThat(map3.size()).isEqualTo(3);
-    assertThat(map4.size()).isEqualTo(2);
-    PersistentSortedMap<String, String> map5 = map4.removeAndCopy("2");
-    assertThat(map.size()).isEqualTo(5);
-    assertThat(map2.size()).isEqualTo(4);
-    assertThat(map3.size()).isEqualTo(3);
-    assertThat(map4.size()).isEqualTo(2);
-    assertThat(map5.size()).isEqualTo(1);
-    PersistentSortedMap<String, String> map6 = map5.removeAndCopy("5");
-    assertThat(map.size()).isEqualTo(5);
-    assertThat(map2.size()).isEqualTo(4);
-    assertThat(map3.size()).isEqualTo(3);
-    assertThat(map4.size()).isEqualTo(2);
-    assertThat(map5.size()).isEqualTo(1);
-    assertThat(map6.size()).isEqualTo(0);
-  }
-
-  @Test
   public void testSizeTracksDuplicateKeyInsertions() {
     // Verify that inserting duplicate keys does not change size() regardless of value
     map = map.putAndCopy("3", "A");
@@ -561,11 +497,10 @@ public class PathCopyingPersistentTreeMapTest {
     // number of entries for each version after every insertion
     int insertionAmount = 1000;
     List<PersistentSortedMap<String, String>> versions = new ArrayList<>();
-    @Var PersistentSortedMap<String, String> current = map;
-    versions.add(current);
+    versions.add(map);
     for (int i = insertionAmount; i >= 1; i--) {
-      current = current.putAndCopy(Integer.toString(i), Integer.toString(i));
-      versions.add(current);
+      map = map.putAndCopy(Integer.toString(i), Integer.toString(i));
+      versions.add(map);
       for (int j = 0; j < versions.size(); j++) {
         assertThat(versions.get(j).size()).isEqualTo(j);
       }
@@ -600,9 +535,9 @@ public class PathCopyingPersistentTreeMapTest {
         assertThat(map.containsKey(Integer.toString(i)))
                 .isEqualTo(oracle.contains(Integer.toString(i)));
 
-        int count = 0;
+        @Var int count = 0;
 
-        for (Map.Entry<String, String> entry : map.entrySet()) {
+        for (Map.Entry<String, String> unused : map.entrySet()) {
           count++;
         }
 

--- a/src/org/sosy_lab/common/collect/PathCopyingPersistentTreeMapTest.java
+++ b/src/org/sosy_lab/common/collect/PathCopyingPersistentTreeMapTest.java
@@ -473,7 +473,7 @@ public class PathCopyingPersistentTreeMapTest {
     assertThat(map.size()).isEqualTo(1);
   }
 
-  private String[] shuffleKeyOrder(int size) {
+  private static String[] shuffleKeyOrder(int size) {
     // Helper method that randomly shuffles key insertion/deletion order
     int[] keyOrder = new int[size];
 

--- a/src/org/sosy_lab/common/collect/PathCopyingPersistentTreeMapTest.java
+++ b/src/org/sosy_lab/common/collect/PathCopyingPersistentTreeMapTest.java
@@ -473,38 +473,54 @@ public class PathCopyingPersistentTreeMapTest {
     assertThat(map.size()).isEqualTo(1);
   }
 
+  private void runInsertionOrder(String[] keyInsertionOrder) {
+    // Helper method for test cases that verify correct key insertion and size tracking
+    // across all versions
+    List<PersistentSortedMap<String, String>> versions = new ArrayList<>();
+    List<Integer> expectedVersionSizes = new ArrayList<>();
+
+    versions.add(map);
+    expectedVersionSizes.add(map.size());
+
+    for (String key : keyInsertionOrder) {
+      map = map.putAndCopy(key, key);
+      versions.add(map);
+      expectedVersionSizes.add(map.size());
+
+      for (int j = 0; j < versions.size(); j++) {
+        assertThat(versions.get(j).size()).isEqualTo(expectedVersionSizes.get(j));
+      }
+    }
+  }
+
   @Test
   public void testSizeTracksAscendingInsertionsAcrossAllVersions() {
     // Insert keys in ascending order and verify that size() reflects the correct
     // number of entries for each version after every insertion
-    int insertionAmount = 1000;
-    List<PersistentSortedMap<String, String>> versions = new ArrayList<>();
-    versions.add(map);
-    for (int i = 1; i <= insertionAmount; i++) {
-      PersistentSortedMap<String, String> previousVersion = versions.get(i - 1);
-      PersistentSortedMap<String, String> version = previousVersion
-      .putAndCopy(Integer.toString(i), Integer.toString(i));
-      versions.add(version);
-      for (int j = 0; j < versions.size(); j++) {
-        assertThat(versions.get(j).size()).isEqualTo(j);
-      }
+    int insertionAmount = 100;
+
+    String[] keyInsertionOrder = new String[insertionAmount];
+
+    for (int i = insertionAmount; i > 0; i--) {
+      keyInsertionOrder[i - 1] = Integer.toString(i);
     }
+
+    runInsertionOrder(keyInsertionOrder);
   }
 
   @Test
   public void testSizeTracksDescendingInsertionsAcrossAllVersions() {
     // Insert keys in descending order and verify that size() reflects the correct
     // number of entries for each version after every insertion
-    int insertionAmount = 1000;
-    List<PersistentSortedMap<String, String>> versions = new ArrayList<>();
-    versions.add(map);
-    for (int i = insertionAmount; i >= 1; i--) {
-      map = map.putAndCopy(Integer.toString(i), Integer.toString(i));
-      versions.add(map);
-      for (int j = 0; j < versions.size(); j++) {
-        assertThat(versions.get(j).size()).isEqualTo(j);
-      }
+    int insertionAmount = 100;
+
+    String[] keyInsertionOrder = new String[insertionAmount];
+
+    for (int i = 0; i < insertionAmount; i++) {
+      keyInsertionOrder[i] = Integer.toString(i + 1);
     }
+
+    runInsertionOrder(keyInsertionOrder);
   }
 
   private void runDeletionOrder(int n, String[] keyDeletionOrder) {

--- a/src/org/sosy_lab/common/collect/PathCopyingPersistentTreeMapTest.java
+++ b/src/org/sosy_lab/common/collect/PathCopyingPersistentTreeMapTest.java
@@ -29,6 +29,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.TreeSet;
 import junit.framework.JUnit4TestAdapter;
 import junit.framework.TestSuite;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -569,5 +570,108 @@ public class PathCopyingPersistentTreeMapTest {
         assertThat(versions.get(j).size()).isEqualTo(j);
       }
     }
+  }
+
+  private void runDeletionOrder(int n, String[] keyDeletionOrder) {
+    // Helper method for test cases that verify correct key deletion and size tracking
+    // across all versions
+    Set<String> oracle = new TreeSet<>();
+    List<Integer> expectedVersionSizes = new ArrayList<>();
+    List<PersistentSortedMap<String, String>> versions = new ArrayList<>();
+
+    for (int i = 1; i <= n; i++) {
+      map = map.putAndCopy(Integer.toString(i), Integer.toString(i));
+      oracle.add(Integer.toString(i));
+    }
+
+    versions.add(map);
+    expectedVersionSizes.add(map.size());
+
+    for (String key : keyDeletionOrder) {
+      map = map.removeAndCopy(key);
+      oracle.remove(key);
+
+      versions.add(map);
+      expectedVersionSizes.add(map.size());
+
+      assertThat(map.size()).isEqualTo(oracle.size());
+
+      for (int i = 1; i <= n; i++) {
+        assertThat(map.containsKey(Integer.toString(i)))
+                .isEqualTo(oracle.contains(Integer.toString(i)));
+
+        int count = 0;
+
+        for (Map.Entry<String, String> entry : map.entrySet()) {
+          count++;
+        }
+
+        assertThat(map.size()).isEqualTo(count);
+
+        for (int j = 0; j < versions.size(); j++) {
+          assertThat(versions.get(j).size()).isEqualTo(expectedVersionSizes.get(j));
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testSizeTracksAscendingDeletionsAcrossAllVersions() {
+    // Insert keys in ascending order and verify that size() reflects the correct
+    // number of entries for each version after every deletion in ascending order
+    int keyAmount = 100;
+    String[] keyDeletionOrder = new String[keyAmount];
+
+    for (int i = 1; i <= keyAmount; i++) {
+      keyDeletionOrder[i - 1] = Integer.toString(i);
+    }
+
+    runDeletionOrder(keyAmount, keyDeletionOrder);
+  }
+
+  @Test
+  public void testSizeTracksDescendingDeletionsAcrossAllVersions() {
+    // Insert keys in ascending order and verify that size() reflects the correct
+    // number of entries for each version after every deletion in descending order
+    int keyAmount = 100;
+    String[] keyDeletionOrder = new String[keyAmount];
+
+    for (int i = keyAmount; i > 0; i--) {
+      keyDeletionOrder[i - 1] = Integer.toString(i);
+    }
+
+    runDeletionOrder(keyAmount, keyDeletionOrder);
+  }
+
+  @Test
+  public void testSizeTracksRandomDeletionsAcrossAllVersions() {
+    // Insert keys in ascending order and verify that size() reflects the correct
+    // number of entries for each version after every deletion in random order
+    int keyAmount = 100;
+    int[] keyDeletionOrder = new int[keyAmount];
+
+    for (int i = 0; i < keyAmount; i++) {
+      keyDeletionOrder[i] = i + 1;
+    }
+
+    // Randomize deletion order using Fisher-Yates shuffle
+
+    Random random = new Random();
+
+    for (int i = keyAmount - 1; i > 0; i--) {
+      int j = random.nextInt(i + 1);
+
+      int temp = keyDeletionOrder[i];
+      keyDeletionOrder[i] = keyDeletionOrder[j];
+      keyDeletionOrder[j] = temp;
+    }
+
+    String[] stringDeletionOrder = new String[keyAmount];
+
+    for (int i = 0; i < keyAmount; i++) {
+      stringDeletionOrder[i] = Integer.toString(keyDeletionOrder[i]);
+    }
+
+    runDeletionOrder(keyAmount, stringDeletionOrder);
   }
 }

--- a/src/org/sosy_lab/common/collect/PathCopyingPersistentTreeMapTest.java
+++ b/src/org/sosy_lab/common/collect/PathCopyingPersistentTreeMapTest.java
@@ -20,15 +20,15 @@ import com.google.common.collect.testing.features.CollectionSize;
 import com.google.common.collect.testing.features.MapFeature;
 import com.google.common.testing.EqualsTester;
 import com.google.errorprone.annotations.Var;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Random;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
-import java.util.List;
-import java.util.ArrayList;
 import junit.framework.JUnit4TestAdapter;
 import junit.framework.TestSuite;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -485,8 +485,8 @@ public class PathCopyingPersistentTreeMapTest {
   public void testSizeTracksMultipleDeletionsAcrossAllVersions() {
     // Insert keys in non-ascending order and verify that size() reflects
     // the number of entries for all versions after each key deletion
-    map = map.putAndCopy("6", "A").putAndCopy("3", "B").
-            putAndCopy("9", "C").putAndCopy("2", "D").putAndCopy("5", "E");
+    map = map.putAndCopy("6", "A").putAndCopy("3", "B").putAndCopy("9", "C")
+    .putAndCopy("2", "D").putAndCopy("5", "E");
     PersistentSortedMap<String, String> map2 = map.removeAndCopy("6");
     assertThat(map.size()).isEqualTo(5);
     assertThat(map2.size()).isEqualTo(4);
@@ -545,8 +545,8 @@ public class PathCopyingPersistentTreeMapTest {
     versions.add(map);
     for (int i = 1; i <= insertionAmount; i++) {
       PersistentSortedMap<String, String> previousVersion = versions.get(i - 1);
-      PersistentSortedMap<String, String> version = previousVersion.
-              putAndCopy(Integer.toString(i), Integer.toString(i));
+      PersistentSortedMap<String, String> version = previousVersion
+      .putAndCopy(Integer.toString(i), Integer.toString(i));
       versions.add(version);
       for (int j = 0; j < versions.size(); j++) {
         assertThat(versions.get(j).size()).isEqualTo(j);

--- a/src/org/sosy_lab/common/collect/PathCopyingPersistentTreeMapTest.java
+++ b/src/org/sosy_lab/common/collect/PathCopyingPersistentTreeMapTest.java
@@ -20,9 +20,15 @@ import com.google.common.collect.testing.features.CollectionSize;
 import com.google.common.collect.testing.features.MapFeature;
 import com.google.common.testing.EqualsTester;
 import com.google.errorprone.annotations.Var;
-
-import java.util.*;
-
+import java.util.Collection;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Random;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.List;
+import java.util.ArrayList;
 import junit.framework.JUnit4TestAdapter;
 import junit.framework.TestSuite;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -438,16 +444,16 @@ public class PathCopyingPersistentTreeMapTest {
     // Verify that a newly created map has no entries and size 0
     assertThat(map.size()).isEqualTo(0);
     assertThat(map.isEmpty()).isTrue();
-    assertThat(map.containsKey(1)).isFalse();
-    assertThat(map.get(1)).isNull();
+    assertThat(map.containsKey("1")).isFalse();
+    assertThat(map.get("1")).isNull();
     assertThat(map.firstEntry()).isNull();
     assertThat(map.lastEntry()).isNull();
   }
 
   @Test
   public void testSizeTracksMultipleInsertionsAcrossAllVersions() {
-    // Insert keys in non-ascending order and verify that size() reflects the number of entries for all versions
-    // after each insertion
+    // Insert keys in non-ascending order and verify that size() reflects
+    // the number of entries for all versions after each insertion
     PersistentSortedMap<String, String> map2 = map.putAndCopy("6", "A");
     assertThat(map.size()).isEqualTo(0);
     assertThat(map2.size()).isEqualTo(1);
@@ -477,8 +483,8 @@ public class PathCopyingPersistentTreeMapTest {
 
   @Test
   public void testSizeTracksMultipleDeletionsAcrossAllVersions() {
-    // Insert keys in non-ascending order and verify that size() reflects the number of entries for all versions
-    // after each key deletion
+    // Insert keys in non-ascending order and verify that size() reflects
+    // the number of entries for all versions after each key deletion
     map = map.putAndCopy("6", "A").putAndCopy("3", "B").
             putAndCopy("9", "C").putAndCopy("2", "D").putAndCopy("5", "E");
     PersistentSortedMap<String, String> map2 = map.removeAndCopy("6");
@@ -532,14 +538,15 @@ public class PathCopyingPersistentTreeMapTest {
 
   @Test
   public void testSizeTracksAscendingInsertionsAcrossAllVersions() {
-    // Insert keys in ascending order and verify that size() reflects the correct number of entries for each version
-    // after every insertion
+    // Insert keys in ascending order and verify that size() reflects the correct
+    // number of entries for each version after every insertion
     int insertionAmount = 1000;
     List<PersistentSortedMap<String, String>> versions = new ArrayList<>();
     versions.add(map);
     for (int i = 1; i <= insertionAmount; i++) {
       PersistentSortedMap<String, String> previousVersion = versions.get(i - 1);
-      PersistentSortedMap<String, String> version = previousVersion.putAndCopy(Integer.toString(i), Integer.toString(i));
+      PersistentSortedMap<String, String> version = previousVersion.
+              putAndCopy(Integer.toString(i), Integer.toString(i));
       versions.add(version);
       for (int j = 0; j < versions.size(); j++) {
         assertThat(versions.get(j).size()).isEqualTo(j);
@@ -549,11 +556,11 @@ public class PathCopyingPersistentTreeMapTest {
 
   @Test
   public void testSizeTracksDescendingInsertionsAcrossAllVersions() {
-    // Insert keys in descending order and verify that size() reflects the correct number of entries for each version
-    // after every insertion
+    // Insert keys in descending order and verify that size() reflects the correct
+    // number of entries for each version after every insertion
     int insertionAmount = 1000;
     List<PersistentSortedMap<String, String>> versions = new ArrayList<>();
-    PersistentSortedMap<String, String> current = map;
+    @Var PersistentSortedMap<String, String> current = map;
     versions.add(current);
     for (int i = insertionAmount; i >= 1; i--) {
       current = current.putAndCopy(Integer.toString(i), Integer.toString(i));

--- a/src/org/sosy_lab/common/collect/PathCopyingPersistentTreeMapTest.java
+++ b/src/org/sosy_lab/common/collect/PathCopyingPersistentTreeMapTest.java
@@ -473,6 +473,35 @@ public class PathCopyingPersistentTreeMapTest {
     assertThat(map.size()).isEqualTo(1);
   }
 
+  private String[] shuffleKeyOrder(int size) {
+    // Helper method that randomly shuffles key insertion/deletion order
+    int[] keyOrder = new int[size];
+
+    for (int i = 0; i < size; i++) {
+      keyOrder[i] = i + 1;
+    }
+
+    // Randomize insertion order using Fisher-Yates shuffle
+
+    Random random = new Random();
+
+    for (int i = size - 1; i > 0; i--) {
+      int j = random.nextInt(i + 1);
+
+      int temp = keyOrder[i];
+      keyOrder[i] = keyOrder[j];
+      keyOrder[j] = temp;
+    }
+
+    String[] stringKeyOrder = new String[size];
+
+    for (int i = 0; i < size; i++) {
+      stringKeyOrder[i] = Integer.toString(keyOrder[i]);
+    }
+
+    return stringKeyOrder;
+  }
+
   private void runInsertionOrder(String[] keyInsertionOrder) {
     // Helper method for test cases that verify correct key insertion and size tracking
     // across all versions
@@ -521,6 +550,15 @@ public class PathCopyingPersistentTreeMapTest {
     }
 
     runInsertionOrder(keyInsertionOrder);
+  }
+
+  @Test
+  public void testSizeTracksRandomInsertionsAcrossAllVersions() {
+    // Insert keys in random order and verify that size() reflects the correct
+    // number of entries for each version after every insertion
+    int insertionAmount = 100;
+
+    runInsertionOrder(shuffleKeyOrder(insertionAmount));
   }
 
   private void runDeletionOrder(int n, String[] keyDeletionOrder) {
@@ -600,30 +638,7 @@ public class PathCopyingPersistentTreeMapTest {
     // Insert keys in ascending order and verify that size() reflects the correct
     // number of entries for each version after every deletion in random order
     int keyAmount = 100;
-    int[] keyDeletionOrder = new int[keyAmount];
 
-    for (int i = 0; i < keyAmount; i++) {
-      keyDeletionOrder[i] = i + 1;
-    }
-
-    // Randomize deletion order using Fisher-Yates shuffle
-
-    Random random = new Random();
-
-    for (int i = keyAmount - 1; i > 0; i--) {
-      int j = random.nextInt(i + 1);
-
-      int temp = keyDeletionOrder[i];
-      keyDeletionOrder[i] = keyDeletionOrder[j];
-      keyDeletionOrder[j] = temp;
-    }
-
-    String[] stringDeletionOrder = new String[keyAmount];
-
-    for (int i = 0; i < keyAmount; i++) {
-      stringDeletionOrder[i] = Integer.toString(keyDeletionOrder[i]);
-    }
-
-    runDeletionOrder(keyAmount, stringDeletionOrder);
+    runDeletionOrder(keyAmount, shuffleKeyOrder(keyAmount));
   }
 }

--- a/src/org/sosy_lab/common/collect/PathCopyingPersistentTreeMapTest.java
+++ b/src/org/sosy_lab/common/collect/PathCopyingPersistentTreeMapTest.java
@@ -20,13 +20,9 @@ import com.google.common.collect.testing.features.CollectionSize;
 import com.google.common.collect.testing.features.MapFeature;
 import com.google.common.testing.EqualsTester;
 import com.google.errorprone.annotations.Var;
-import java.util.Collection;
-import java.util.Map;
-import java.util.NavigableMap;
-import java.util.Random;
-import java.util.Set;
-import java.util.SortedMap;
-import java.util.TreeMap;
+
+import java.util.*;
+
 import junit.framework.JUnit4TestAdapter;
 import junit.framework.TestSuite;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -433,5 +429,138 @@ public class PathCopyingPersistentTreeMapTest {
     // instead of letting Truth check containment (which is not guaranteed to call containsAll).
     assertThat(second.entrySet().containsAll(first.entrySet())).isFalse();
     assertThat(first.entrySet().containsAll(second.entrySet())).isFalse();
+  }
+
+  // Test cases for size tracking
+
+  @Test
+  public void testEmptyMapHasSizeZero() {
+    // Verify that a newly created map has no entries and size 0
+    assertThat(map.size()).isEqualTo(0);
+    assertThat(map.isEmpty()).isTrue();
+    assertThat(map.containsKey(1)).isFalse();
+    assertThat(map.get(1)).isNull();
+    assertThat(map.firstEntry()).isNull();
+    assertThat(map.lastEntry()).isNull();
+  }
+
+  @Test
+  public void testSizeTracksMultipleInsertionsAcrossAllVersions() {
+    // Insert keys in non-ascending order and verify that size() reflects the number of entries for all versions
+    // after each insertion
+    PersistentSortedMap<String, String> map2 = map.putAndCopy("6", "A");
+    assertThat(map.size()).isEqualTo(0);
+    assertThat(map2.size()).isEqualTo(1);
+    PersistentSortedMap<String, String> map3 = map2.putAndCopy("3", "B");
+    assertThat(map.size()).isEqualTo(0);
+    assertThat(map2.size()).isEqualTo(1);
+    assertThat(map3.size()).isEqualTo(2);
+    PersistentSortedMap<String, String> map4 = map3.putAndCopy("9", "C");
+    assertThat(map.size()).isEqualTo(0);
+    assertThat(map2.size()).isEqualTo(1);
+    assertThat(map3.size()).isEqualTo(2);
+    assertThat(map4.size()).isEqualTo(3);
+    PersistentSortedMap<String, String> map5 = map4.putAndCopy("2", "D");
+    assertThat(map.size()).isEqualTo(0);
+    assertThat(map2.size()).isEqualTo(1);
+    assertThat(map3.size()).isEqualTo(2);
+    assertThat(map4.size()).isEqualTo(3);
+    assertThat(map5.size()).isEqualTo(4);
+    PersistentSortedMap<String, String> map6 = map5.putAndCopy("5", "E");
+    assertThat(map.size()).isEqualTo(0);
+    assertThat(map2.size()).isEqualTo(1);
+    assertThat(map3.size()).isEqualTo(2);
+    assertThat(map4.size()).isEqualTo(3);
+    assertThat(map5.size()).isEqualTo(4);
+    assertThat(map6.size()).isEqualTo(5);
+  }
+
+  @Test
+  public void testSizeTracksMultipleDeletionsAcrossAllVersions() {
+    // Insert keys in non-ascending order and verify that size() reflects the number of entries for all versions
+    // after each key deletion
+    map = map.putAndCopy("6", "A").putAndCopy("3", "B").
+            putAndCopy("9", "C").putAndCopy("2", "D").putAndCopy("5", "E");
+    PersistentSortedMap<String, String> map2 = map.removeAndCopy("6");
+    assertThat(map.size()).isEqualTo(5);
+    assertThat(map2.size()).isEqualTo(4);
+    PersistentSortedMap<String, String> map3 = map2.removeAndCopy("3");
+    assertThat(map.size()).isEqualTo(5);
+    assertThat(map2.size()).isEqualTo(4);
+    assertThat(map3.size()).isEqualTo(3);
+    PersistentSortedMap<String, String> map4 = map3.removeAndCopy("9");
+    assertThat(map.size()).isEqualTo(5);
+    assertThat(map2.size()).isEqualTo(4);
+    assertThat(map3.size()).isEqualTo(3);
+    assertThat(map4.size()).isEqualTo(2);
+    PersistentSortedMap<String, String> map5 = map4.removeAndCopy("2");
+    assertThat(map.size()).isEqualTo(5);
+    assertThat(map2.size()).isEqualTo(4);
+    assertThat(map3.size()).isEqualTo(3);
+    assertThat(map4.size()).isEqualTo(2);
+    assertThat(map5.size()).isEqualTo(1);
+    PersistentSortedMap<String, String> map6 = map5.removeAndCopy("5");
+    assertThat(map.size()).isEqualTo(5);
+    assertThat(map2.size()).isEqualTo(4);
+    assertThat(map3.size()).isEqualTo(3);
+    assertThat(map4.size()).isEqualTo(2);
+    assertThat(map5.size()).isEqualTo(1);
+    assertThat(map6.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void testSizeTracksDuplicateKeyInsertions() {
+    // Verify that inserting duplicate keys does not change size() regardless of value
+    map = map.putAndCopy("3", "A");
+    assertThat(map.size()).isEqualTo(1);
+    PersistentSortedMap<String, String> map2 = map.putAndCopy("3", "A");
+    assertThat(map.size()).isEqualTo(1);
+    assertThat(map2.size()).isEqualTo(1);
+    PersistentSortedMap<String, String> map3 = map.putAndCopy("3", "B");
+    assertThat(map.size()).isEqualTo(1);
+    assertThat(map3.size()).isEqualTo(1);
+  }
+
+  @Test
+  public void testSizeTracksMissingKeyInsertions() {
+    // Verify that deleting missing keys does not change size()
+    map = map.putAndCopy("3", "A");
+    assertThat(map.size()).isEqualTo(1);
+    map = map.removeAndCopy("2");
+    assertThat(map.size()).isEqualTo(1);
+  }
+
+  @Test
+  public void testSizeTracksAscendingInsertionsAcrossAllVersions() {
+    // Insert keys in ascending order and verify that size() reflects the correct number of entries for each version
+    // after every insertion
+    int insertionAmount = 1000;
+    List<PersistentSortedMap<String, String>> versions = new ArrayList<>();
+    versions.add(map);
+    for (int i = 1; i <= insertionAmount; i++) {
+      PersistentSortedMap<String, String> previousVersion = versions.get(i - 1);
+      PersistentSortedMap<String, String> version = previousVersion.putAndCopy(Integer.toString(i), Integer.toString(i));
+      versions.add(version);
+      for (int j = 0; j < versions.size(); j++) {
+        assertThat(versions.get(j).size()).isEqualTo(j);
+      }
+    }
+  }
+
+  @Test
+  public void testSizeTracksDescendingInsertionsAcrossAllVersions() {
+    // Insert keys in descending order and verify that size() reflects the correct number of entries for each version
+    // after every insertion
+    int insertionAmount = 1000;
+    List<PersistentSortedMap<String, String>> versions = new ArrayList<>();
+    PersistentSortedMap<String, String> current = map;
+    versions.add(current);
+    for (int i = insertionAmount; i >= 1; i--) {
+      current = current.putAndCopy(Integer.toString(i), Integer.toString(i));
+      versions.add(current);
+      for (int j = 0; j < versions.size(); j++) {
+        assertThat(versions.get(j).size()).isEqualTo(j);
+      }
+    }
   }
 }


### PR DESCRIPTION
Extend size tracking of [PathCopyingPersistentTreeMap.java](https://github.com/sosy-lab/java-common-lib/blob/extend_persistent_path_copying_map_with_size_tracking/src/org/sosy_lab/common/collect/PathCopyingPersistentTreeMap.java) by reducing runtime complexity of size() from O(n) to O(1).

Extend [PathCopyingPersistentTreeMapTest.java](https://github.com/sosy-lab/java-common-lib/blob/extend_persistent_path_copying_map_with_size_tracking/src/org/sosy_lab/common/collect/PathCopyingPersistentTreeMapTest.java) to verify correct size tracking across all versions to ensure full persistence.

The benchmark results can be found here:

[results.integration-nightly-value.table.html](https://github.com/user-attachments/files/26775652/results.integration-nightly-value.table.html)

